### PR TITLE
adds lazy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ pytest
 
 ## Quick Start
 
-Extract `home`, `work`, `education`, `shop` and various other activity locations ("facilities") for the Isle of Man, using the following command (the path is given from OSMOX project root):
+Extract `home`, `work`, `education`, `shop` and various other activity locations ("facilities") for the Isle of Man, using the following steps (paths is given from OSMOX project root):
+
+First download `isle-of-man-latest.osm.pbf` from [geobabrik](https://download.geofabrik.de/europe/isle-of-man.html) and place in an `example` directory.
 
 ```{sh}
-osmox run configs/example.json example_data/isle-of-man.osm example -crs "epsg:27700"
+osmox run configs/example.json example/isle-of-man.osm example -crs "epsg:27700"
 ```
 
 After about 30 seconds, you should find the outputs in geojson format in the specified `example` directory. The geojson file contains locations for the extracted facilities, and each facility includes a number of features with coordinates given in WGS-84 (EPSG:4326) coordinate reference system (CRS), so that they can be quickly inspected via [kepler](https://kepler.gl) or equivalent.
@@ -91,8 +93,6 @@ After about 30 seconds, you should find the outputs in geojson format in the spe
         ...
 ```
 
-
-
 ![isle of man floor areas](./readme_fixtures/floor-areas.png)
 *^ Isle of Man facility `floor_area` feature. Approximated based on polygon areas and floor labels or sensible defaults.*
 
@@ -106,9 +106,12 @@ After about 30 seconds, you should find the outputs in geojson format in the spe
 ```{sh}
 osmox run --help
 
+Usage: osmox run [OPTIONS] CONFIG_PATH INPUT_PATH OUTPUT_PATH
+
 Options:
   -crs, --crs TEXT  crs string eg (default): 'epsg:27700' (UK grid)
   -s, --single_use  split multi-activity facilities into multiple single-activity facilities
+  -l, --lazy        if filtered object already has a label, do not search for more (supresses multi-use but is faster)
   --help            Show this message and exit.
 ```
 

--- a/osmox/build.py
+++ b/osmox/build.py
@@ -117,29 +117,22 @@ class Object:
             """
 
     def add_tags(self, osm_objects):
-        print(f"adding tag to {self.idx}")
-        print(f"existing = {self.activity_tags}")
         for o in osm_objects:
             if o.activity_tags:
                 self.activity_tags.extend(o.activity_tags)
-        print(f"updated = {self.activity_tags}")
 
     def apply_default_tag(self, tag):
         self.activity_tags = [OSMTag(tag[0], tag[1])]
 
     def assign_points(self, points):
-        print("assigning points")
         snaps = [c for c in points.intersection(self.geom.bounds)]
-        print(f"snaps = {snaps}")
         if snaps:
             self.add_tags(snaps)
             return True
 
     def assign_areas(self, areas):
-        print("assigning areas")
         snaps = [c for c in areas.intersection(self.geom.bounds)]
         snaps = [c for c in snaps if c.geom.contains(self.geom.centroid)]
-        print(f"snaps = {snaps}")
         if snaps:
             self.add_tags(snaps)
             return True
@@ -316,27 +309,22 @@ class ObjectHandler(osmium.SimpleHandler):
         """
 
         for obj in helpers.progressBar(self.objects, prefix='Progress:', suffix='Complete', length=50):
-            print(obj.idx, obj.activity_tags)
 
             if obj.activity_tags:
-                print("existing:", obj.idx, obj.activity_tags)
                 # if an onject already has activity tags, continue
                 self.log["existing"] += 1
 
             if obj.assign_points(self.points):
-                print("pre point assignment:", obj.idx, obj.activity_tags)
                 # else try to assign activity tags based on contained point objects
                 self.log["points"] += 1
                 continue
 
             if obj.assign_areas(self.areas):
-                print("pre area assignment:", obj.idx, obj.activity_tags)
                 # else try to assign activity tags based on containing area objects
                 self.log["areas"] += 1
                 continue
 
             if self.default_tags and not obj.activity_tags:
-                print("defaults need to be assigned...", obj.idx, obj.activity_tags)
                 # otherwise apply defaults if set
                 self.log["defaults"] += 1
                 for a in self.default_tags:
@@ -455,19 +443,11 @@ class ObjectHandler(osmium.SimpleHandler):
         return MultiPoint(targets)
 
     def geodataframe(self, single_use=False):
-        print("+++++++++++++++++++")
-        # print(self.objects)
-        print(single_use)
 
         if single_use:
-            print("SINGLE USE")
-
             df = pd.DataFrame(
                 (summary for o in self.objects for summary in o.single_activity_summaries())
             )
-            print("====")
-            print(df)
-            print("====")
             return gp.GeoDataFrame(df, geometry='geometry', crs=self.crs)
 
         df = pd.DataFrame(

--- a/osmox/build.py
+++ b/osmox/build.py
@@ -199,7 +199,7 @@ class ObjectHandler(osmium.SimpleHandler):
         from_crs='epsg:4326',
         lazy=False,
         level=logging.DEBUG
-        ):
+    ):
 
         super().__init__()
         logging.basicConfig(level=level)
@@ -292,7 +292,6 @@ class ObjectHandler(osmium.SimpleHandler):
             self.add_object(idx=a.id, osm_tags=a.tags, activity_tags=activity_tags, geom=self.fab_area(a))
         elif activity_tags:
             self.add_area(idx=a.id, activity_tags=activity_tags, geom=self.fab_area(a))
-
 
     def assign_tags(self):
         """

--- a/osmox/main.py
+++ b/osmox/main.py
@@ -58,8 +58,6 @@ def run(config_path, input_path, output_path, crs, single_use, lazy):
         os.mkdir(output_path)
     
     logger.info(f"Creating handler with crs: {crs}.")
-    print(crs)
-    print(lazy)
     if single_use:
         logger.info(f"Handler is single-use, different activities will get unique locations. even if these are duplicated.")
     if lazy:

--- a/osmox/main.py
+++ b/osmox/main.py
@@ -1,4 +1,3 @@
-from linecache import lazycache
 import logging
 import os
 
@@ -56,12 +55,12 @@ def run(config_path, input_path, output_path, crs, single_use, lazy):
     if not os.path.exists(output_path):
         logger.info(f'Creating output directory: {output_path}')
         os.mkdir(output_path)
-    
+
     logger.info(f"Creating handler with crs: {crs}.")
     if single_use:
-        logger.info(f"Handler is single-use, different activities will get unique locations. even if these are duplicated.")
+        logger.info("Handler is single-use, activities will get unique locations.")
     if lazy:
-        logger.info(f"Handler will be using lazy assignment, this may suppress some multi-use.")
+        logger.info("Handler will be using lazy assignment, this may suppress some multi-use.")
 
     handler = build.ObjectHandler(
         config=cnfg,

--- a/tests/fixtures/test_config_leisure.json
+++ b/tests/fixtures/test_config_leisure.json
@@ -3,7 +3,7 @@
         "leisure": ["pitch", "park", "playground"]
     },
 
-    "object_features": ["units", "transit_distance", "levels", "area", "floor_area"],
+    "object_features": ["units", "levels", "area", "floor_area"],
 
     "default_tags": [["building", "residential"]],
 

--- a/tests/test_activityhandler.py
+++ b/tests/test_activityhandler.py
@@ -126,7 +126,7 @@ def test_leisure_config():
 
 @pytest.fixture()
 def leisureHandler(test_leisure_config):
-    return build.ObjectHandler(test_leisure_config, crs='epsg:4326')
+    return build.ObjectHandler(test_leisure_config, crs='epsg:4326', lazy=False)
 
 
 def test_leisure_handler(leisureHandler):


### PR DESCRIPTION
I noticed that the current activity assignment code:

```
        for obj in helpers.progressBar(self.objects, prefix='Progress:', suffix='Complete', length=50):

            if obj.activity_tags:
                # if an onject already has activity tags, continue
                self.log["existing"] += 1
                continue

            if obj.assign_points(self.points):
                # else try to assign activity tags based on contained point objects
                self.log["points"] += 1
                continue

            if obj.assign_areas(self.areas):
                # else try to assign activity tags based on containing area objects
                self.log["areas"] += 1
                continue

            if self.default_tags:
               ...
```
was supressing a lot of multi-use buildings. This was happening because for building that already had a useful tag (` if obj.activity_tags:`) then the code would `continue` skipping the point and area adding.

Therefore I have refactored this as `assign_tags_lazy` which can be accessed via the cli via `-l`.

The default is now `assign_tags_full` which does not have the continue statements so will labour on through point and area asignment. Which is slower but captured more multi-use facilities.