### PR TITLE
Python 3.7 & 3.11 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Click==7.1.2
 flake8==5.0.4
 geopandas>=0.9.0
-osmium==3.1.0
+osmium>=3.1.0
 pandas>=1.2.4
-pyproj==3.1.0
+pyproj>=3.1.0
 pytest==6.2.4
 pytest-cov==2.8.1
 pytest-mock==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click==7.1.2
 flake8==5.0.4
 geopandas>=0.9.0
-osmium==3.4.0
+osmium>=3.4.0
 pandas>=1.2.4
 pyproj>=3.1.0
 pytest==6.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click==7.1.2
 flake8==5.0.4
 geopandas>=0.9.0
-osmium>=3.1.0
+osmium==3.4.0
 pandas>=1.2.4
 pyproj>=3.1.0
 pytest==6.2.4


### PR DESCRIPTION
Closes #32 

Based on @mfitz issue [here](https://github.com/arup-group/osmox/issues/32), these changes to the requirements.txt seem to enable osmox to work in both a Python 3.7 and 3.11 in virtual environments on my machine. I've had seperate issues relating to me running this on an M1, so would be useful to see if others are able to run this ok with both python versions. 

I originally just left the option as >= for both packages as below and this worked
```
diff requirements.txt requirements-3.11.txt
4c4
< osmium==3.1.0
---
> osmium>=3.4.0
6c6
< pyproj==3.1.0
---
> pyproj>=3.1.0
```

Assuming that it would be better to pin the osmium & pyproj to specific versions (?) I've found that `osmium==3.4.0` is the crossover for support on both so I've changed it to that for now. The pyproj seems to need to stay with this `>=` flexibility though.