### PR TITLE
Upgrade the GDAL python library version in the CI build

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -28,7 +28,7 @@ jobs:
         export C_INCLUDE_PATH=/usr/include/gdal
         sudo apt-get install ca-certificates
         export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-        pip install GDAL==3.0.2
+        pip install GDAL==3.4.1
         pip install -e .
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
Fixes the build by syncing the version of the GDAL python library with the version of the corresponding native `libgdal-dev` library.