### PR TITLE
Add docs and issue / PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,42 @@
+name: Bug Report
+description: Report a bug that leads to osmox not working as expected.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us what you expected to happen.
+      placeholder: Tell us what you see!
+      value: "Something unexpected happened!"
+    validations:
+      required: true
+  - type: checkboxes
+    id: operating-systems
+    attributes:
+      label: Which operating systems have you used?
+      description: You may select more than one.
+      options:
+        - label: macOS
+        - label: Windows
+        - label: Linux
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: What version of osmox are you using?
+      placeholder: v0.1.0
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/DOCS.yml
+++ b/.github/ISSUE_TEMPLATE/DOCS.yml
@@ -1,0 +1,53 @@
+name: Report a documentation issue
+description: Missing, incorrect, or confusing information in our docs? Report a documentation issue
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        Please describe the inconsistency or issue you have found in
+        [our documentation](https://arup-group.github.io/osmox)
+        or indicate where you feel there is a need for improvement. Furthermore,
+        explain the severity of the issue, i.e., its impact on you and potentially
+        other users.
+    validations:
+      required: true
+
+  - type: textarea
+    id: related-links
+    attributes:
+      label: Related links
+      description: >-
+        Please list all links to the sections of [our documentation](https://arup-group.github.io/osmox)
+        that are impacted by the issue you described above. If applicable,
+        add screenshots. Additionally, list links to possibly related open
+        and closed [issues](https://github.com/arup-group/osmox/issues)
+        and [discussions](https://github.com/arup-group/osmox/discussions)
+        you encountered when searching our issue tracker.
+      value: |
+        -
+        -
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: Which version of the documentation are you referring to?
+      placeholder: v0.1.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed change
+      description: >-
+        This field is optional. You may provide an improvement proposal for our
+        documentation by describing your suggestion in the text field below or
+        creating a pull request after reporting this issue referencing the issue.

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: Suggest an idea for osmox.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for letting us know about your idea!
+  - type: textarea
+    id: description
+    attributes:
+      label: What can be improved?
+      placeholder: Tell us what you would like to see!
+      value: "osmox should be more memory efficient!"
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: What version of osmox are you using?
+      placeholder: v0.1.0
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+Fixes # .
+
+## Checklist
+
+Any checks which are not relevant to the PR can be pre-checked by the PR creator.
+All others should be checked by the reviewer(s).
+You can add extra checklist items here if required by the PR.
+
+- [ ] CHANGELOG updated
+- [ ] Tests added to cover contribution
+- [ ] Documentation updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Recommended installation instructions changed from using `pip` to creating a `mamba` environment.
-- Supported and tested Python versions updated to py3.10 - py3.12.
-
+- Recommended installation instructions changed from using `pip` to creating a `mamba` environment [#38](https://github.com/arup-group/osmox/pull/38).
+- Supported and tested Python versions updated to py3.10 - py3.12 [#38](https://github.com/arup-group/osmox/pull/38).
+- Majority of documentation moved from README to dedicated documentation site: https://arup-group.github.io/osmox [#40](https://github.com/arup-group/osmox/pull/40).
 
 ## [v0.2.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,59 +1,105 @@
-# Contributing
+# Contributing guidelines
 
-When it comes to planning in the built environment, we think transparency is critical. The shape and operations of our shared infrastructure and public spaces impacts individuals’ access to employment opportunities, education, social communities, clean air, and safe mobility options. 
-We think open source, agent based models are the future for transparent, granular city planning. To help make these models a little bit more realistic, we built OSMOX - a tool for extracting locations and features from OpenStreetMap (OSM) data.
+We're really glad you're reading this, because we need volunteer developers to help maintain this project.
 
-Thank you for considering contributing to OSMOX! We're really excited to hear your opinions on the project and any ideas you may have on how it can be better!
+Some of the resources to look at if you're interested in contributing:
 
-Please note we have a code of conduct. Please follow it in all your interactions with the project.
+* Look at open issues tagged with ["help wanted"](https://github.com/arup-group/osmox/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and ["good first issue"](https://github.com/arup-group/osmox/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+* Look at the [contributing guide in our documentation](https://arup-group.github.io/osmox/contributing)
 
-## Ways to Contribute
+## Licensing
+By contributing to osmox, i.e. through opening a pull request, you represent that your contributions are your own original work and that you have the right to license them, and you agree that your contributions are licensed under the MIT license.
+## Reporting bugs and requesting features
 
-There are a number of ways you can contribute to the project. The major two are:
-- Submitting a GitHub issue. This could involve:
-    - Logging a bug or undesirable behaviour
-    - Recording area of possible improvement
-    - Requesting a change or addition of a new feature
-- Contributing code. Our work is never done, if you have an idea how you could make OSMOX better or if you think you could generalise it:
-    - You can outline the new feature or desired behaviour in a GitHub issue and send us an email on [citymodelling@arup.com](mailto:citymodelling@arup.com) 
-    to let us know you're willing to work on it. We may invite you for a brief rubber-ducking session to go through your idea in more detail. The aim is to mature your idea with one (or more) OSMOX developers and to flag any possible blocks or implementation issues to be aware of.
-    - Please follow advice below on Contributing Code, working in a branch and the Pull Request process.
-    - You may continue to, and are encouraged to, keep in touch and reach out to us throughout your development work.
+You can open an issue on GitHub to report bugs or request new osmox features.
+Follow these links to submit your issue:
 
-See this helpful site on [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/) for more ideas on how you could contribute. Get in touch with us via email [citymodelling@arup.com](mailto:citymodelling@arup.com).
+- [Report bugs or other problems while running osmox](https://github.com/arup-group/osmox/issues/new?template=BUG-REPORT.yml).
+If reporting an error, please include a full traceback in your issue.
 
-## Submitting Issues
+- [Request features that osmox does not already include](https://github.com/arup-group/osmox/issues/new?template=FEATURE-REQUEST.yml).
 
-If you have an idea for an enhancement, a change or addition of new feature or behaviour for OSMOX or a record of a bug you can communicate this to us in detail by sending us an email on [citymodelling@arup.com](mailto:citymodelling@arup.com) 
- 
-A good issue will outline the problem in a full written format. It is helpful to include screenshots, especially to highlight any physical issues with the network. It is also helpful to include why you think the new feature would be useful, what problem is it solving and whether there is a real-world cases study that would benefit from this 
-improvement.
+- [Report missing or inconsistent information in our documentation](https://github.com/arup-group/osmox/issues/new?template=DOCS.yml).
 
-In case of bugs, please provide the full error message, the OS and 
-information about the environment in which the process had been ran. It is also helpful to include a small 
-(if possible) set of data on which the problem can be recreated---at the very least, a thorough description of the input data should be included.
+- [Any other issue](https://github.com/arup-group/osmox/issues/new).
 
-## Contributing Code - Pull Request Process
+## Submitting changes
 
-To find beginner-friendly issues that you might want to take a run at, look [here](https://github.com/arup-group/osmox/contribute).
+Look at the [development guide in our documentation](https://arup-group.github.io/osmox/contributing) for information on how to get set up for development.
 
-1. All new work is done in a branch taken from master, details can be found here:
-[feature branch workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow)
-2. Ensure your work is covered by unit tests to the required percentage level. This script 
-[`scripts/code-coverage.sh`](https://github.com/arup-group/osmox/blob/master/scripts/code-coverage.sh)
- will help both in checking that the coverage level is satisfied and investigating places in code that have not been covered by the tests (via an output file `reports/coverage/index.html` which can be viewed in a browser).
-3. Provide [docstrings](https://www.python.org/dev/peps/pep-0257/) for new methods.
-4. Perform linting locally using ```flake8 . --max-line-length 120 --count  --show-source --statistics --exclude=scripts,tests```
-5. Add or update dependencies in `requirements.txt` if applicable.
-6. Ensure the CI build pipeline (Actions tab in GitHub) completes successfully for your branch. The pipeline performs automated `PEP8` checks and runs unit tests in a fresh environment, as well as installation of all dependencies.
-7. You may use example data already in `example_data` directory of this repo, or add more (small amount of) data to it to show off your new features.
-8. Add section in the `README.md` which shows usage of your new feature.
-9. Submit your Pull Request (see [GitHub Docs on Creating a Pull Request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)),
- describing the feature, linking to any relevant GitHub issues and request review from at 
-least two developers. (Please take a look at latest commits to find out which developers you should request review from).
-10. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
-do not have permission to do that, please request one of the reviewers to merge it for you.
+<!--- the "--8<--" html comments define what part of this file to add to the index page of the documentation -->
+<!--- --8<-- [start:docs] -->
+
+To contribute changes:
+
+1. Fork the project on GitHub.
+2. Create a feature branch to work on in your fork (`git checkout -b new-fix-or-feature`).
+3. Test your changes using `pytest`.
+4. Commit your changes to the feature branch (you should have `pre-commit` installed to ensure your code is correctly formatted when you commit changes).
+5. Push the branch to GitHub (`git push origin new-fix-or-feature`).
+6. On GitHub, create a new [pull request](https://github.com/arup-group/osmox/pull/new/main) from the feature branch.
+
+### Pull requests
+
+Before submitting a pull request, check whether you have:
+
+* Added your changes to `CHANGELOG.md`.
+* Added or updated documentation for your changes.
+* Added tests if you implemented new functionality.
+
+When opening a pull request, please provide a clear summary of your changes!
+
+### Commit messages
+
+Please try to write clear commit messages. One-line messages are fine for small changes, but bigger changes should look like this:
+
+    A brief summary of the commit (max 50 characters)
+
+    A paragraph or bullet-point list describing what changed and its impact,
+    covering as many lines as needed.
+
+### Code conventions
+
+Start reading our code and you'll get the hang of it.
+
+We mostly follow the official [Style Guide for Python Code (PEP8)](https://www.python.org/dev/peps/pep-0008/).
+
+We have chosen to use the uncompromising code formatter [`black`](https://github.com/psf/black/) and the linter [`ruff`](https://beta.ruff.rs/docs/).
+When run from the root directory of this repo, `pyproject.toml` should ensure that formatting and linting fixes are in line with our custom preferences (e.g., 100 character maximum line length).
+The philosophy behind using `black` is to have uniform style throughout the project dictated by code.
+Since `black` is designed to minimise diffs, and make patches more human readable, this also makes code reviews more efficient.
+To make this a smooth experience, you should run `pre-commit install` after setting up your development environment, so that `black` makes all the necessary fixes to your code each time you commit, and so that `ruff` will highlight any errors in your code.
+If you prefer, you can also set up your IDE to run these two tools whenever you save your files, and to have `ruff` highlight erroneous code directly as you type.
+Take a look at their documentation for more information on configuring this.
+
+We require all new contributions to have docstrings for all modules, classes and methods.
+When adding docstrings, we request you use the [Google docstring style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
+
+## Release checklist
+
+### Pre-release
+
+- [ ] Make sure all unit and integration tests pass (This is best done by creating a pre-release pull request).
+- [ ] Re-run tutorial Jupyter notebooks (`pytest examples/ --overwrite`).
+- [ ] Make sure documentation builds without errors (`mike deploy [version]`, where `[version]` is the current minor release of the form `X.Y`).
+- [ ] Make sure the [changelog][changelog] is up-to-date, especially that new features and backward incompatible changes are clearly marked.
+
+### Create release
+
+- [ ] Bump the version number in `src/osmox/__init__.py`
+- [ ] Update the [changelog][changelog] with final version number of the form `vX.Y.Z`, release date, and [github `compare` link](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/comparing-commits) (at the bottom of the page).
+- [ ] Commit with message `Release vX.Y.Z`, then add a `vX.Y.Z` tag.
+- [ ] Create a release pull request to verify that the conda package builds successfully.
+- [ ] Once the PR is approved and merged, create a release through the GitHub web interface, using the same tag, titling it `Release vX.Y.Z` and include all the changelog elements that are *not* flagged as **internal**.
+
+### Post-release
+
+- [ ] Update the changelog, adding a new `[Unreleased]` heading.
+- [ ] Update `src/osmox/__init__.py` to the next version appended with `.dev0`, in preparation for the next main commit.
+
+
+<!--- --8<-- [end:docs] -->
 
 ## Attribution
 
-The Contribution Guide was adapted from [PurpleBooth's Template](https://gist.github.com/PurpleBooth/b24679402957c63ec426).
+The layout and content of this document is partially based on the [Calliope project's contribution guidelines](https://github.com/calliope-project/calliope/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-﻿# OSMOX
+﻿<!--- the "--8<--" html comments define what part of the README to add to the index page of the documentation -->
+<!--- --8<-- [start:docs] -->
+# OSMOX
 
 A tool for extracting locations and features from OpenStreetMap (OSM) data.
 
@@ -16,17 +18,23 @@ Under the hood, OSMOX is a collection of labelling and GIS-type operations:
 
 Once assembled, these form part of our wider pipeline. But as a standalone tool, OSMOX is useful for extracting insights from OSM in a reproducible manner.
 
- ![isle of man distance_to_nearest_transit](./readme_fixtures/distance-to-transit.png)
+![isle of man distance_to_nearest_transit](resources/distance-to-transit.png)
 *^ Isle of Man `distance_to_nearest_transit`.*
 
-## Install
+<!--- --8<-- [end:docs] -->
+
+## Documentation
+
+For more detailed instructions, see our [documentation](https://arup-group.github.io/osmox/latest).
+
+## Installation
 
 OSMOX can be installed in Python environments from version 3.10 upwards.
 
-Note: you can use the instructions [here](#using-docker) to build a Docker image for OSMOX and run it in a container if you cannot install it locally.
+Note: you can use the instructions [here](#as-a-user-docker-image) to build a Docker image for OSMOX and run it in a container if you cannot install it locally.
 This builds in a Python 3.12 environment.
 
-### As a Docker image
+### As a user (Docker image)
 
 ```shell
 git clone git@github.com:arup-group/osmox.git
@@ -34,10 +42,11 @@ cd osmox
 docker build -t "osmox" .
 ```
 
-### As a Python package
+### As a user (Python package)
 
 To install osmox, we recommend using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager:
 
+<!--- --8<-- [start:docs-install-user] -->
 ``` shell
 git clone git@github.com:arup-group/osmox.git
 cd osmox
@@ -45,9 +54,11 @@ mamba create -n osmox -c conda-forge -c city-modelling-lab --file requirements/b
 mamba activate osmox
 pip install --no-deps .
 ```
+<!--- --8<-- [end:docs-install-user] -->
 
-### Installing a development environment
+### As a developer
 
+<!--- --8<-- [start:docs-install-dev] -->
 ``` shell
 git clone git@github.com:arup-group/osmox.git
 cd osmox
@@ -55,363 +66,33 @@ mamba create -n osmox -c conda-forge -c city-modelling-lab --file requirements/b
 mamba activate osmox
 pip install --no-deps -e .
 ```
+<!--- --8<-- [end:docs-install-dev] -->
 
-## Quick Start
+For more detailed instructions, see our [documentation](https://arup-group.github.io/osmox/latest/installation/).
 
-Extract `home`, `work`, `education`, `shop` and various other activity locations ("facilities") for the Isle of Man, using the following steps (paths is given from OSMOX project root):
+## Contributing
 
-First download `isle-of-man-latest.osm.pbf` from [geobabrik](https://download.geofabrik.de/europe/isle-of-man.html) and place in an `example` directory.
+There are many ways to contribute to osmox.
+Before making contributions to the osmox source code, see our contribution guidelines and follow the [development install instructions](#as-a-developer).
 
-```{sh}
-osmox run configs/example.json example/isle-of-man-latest.osm.pbf isle-of-man -crs epsg:27700 -l
+If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:
+
+- `pre-commit`: run `pre-commit install` in your command line to load inbuilt checks that will run every time you commit your changes.
+The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [pep8 standard](https://peps.python.org/pep-0008/).
+You can also run these checks yourself at any time to ensure staged changes are clean by simple calling `pre-commit`.
+- `pytest` - run the unit test suite and check test coverage.
+- `pytest -p memray -m "high_mem" --no-cov` (not available on Windows) - after installing memray (`mamba install memray pytest-memray`), test that memory and time performance does not exceed benchmarks.
+
+For more information, see our [documentation](https://arup-group.github.io/osmox/latest/contributing/).
+
+## Building the documentation
+
+If you are unable to access the online documentation, you can build the documentation locally.
+First, [install a development environment of osmox](https://arup-group.github.io/osmox/latest/contributing/coding/), then deploy the documentation using [mike](https://github.com/jimporter/mike):
+
+```
+mike deploy develop
+mike serve
 ```
 
-After about 30 seconds, you should find the outputs in geojson format in the same `example` directory as your OSM input file. The geojson file contains locations for the extracted facilities, and each facility includes a number of features with coordinates given in WGS-84 (EPSG:4326) coordinate reference system (CRS), so that they can be quickly inspected via [kepler](https://kepler.gl) or equivalent.
-
-`-l` is short for `--lazy` which helps osmox run a little faster.
-
-```{geojson}
-{
-    "type": "FeatureCollection",
-    "features": [
-        ...
-        {
-        "id": "13589",
-        "type": "Feature",
-        "properties": {
-            "activities": "home",
-            "area": 196,
-            "distance_to_nearest_education": 816.4434678355371,
-            "distance_to_nearest_medical": 366.81198701080626,
-            "distance_to_nearest_shop": 133.12877450643526,
-            "distance_to_nearest_transit": 122.33125535187033,
-            "floor_area": 392.0,
-            "id": 1869954720,
-            "levels": 2.0,
-            "units": 1
-            },
-        "geometry": {
-            "type": "Point",
-            "coordinates": [220894.60596542264, 467332.85704661923]
-            }
-        },
-        ...
-```
-
-![isle of man floor areas](./readme_fixtures/floor-areas.png)
-*^ Isle of Man facility `floor_area` feature. Approximated based on polygon areas and floor labels or sensible defaults.*
-
-![isle of man activites](./readme_fixtures/activities.png)
-*^ Isle of Man `activities` feature. For simulations we use this information to control what agents can do where, but this is also a good disagregate proxy for land-use. In this example, blue areas are residential, orange commercial and brown is other work places.*
-
-## OSMOX Run
-
-`osmox run <CONFIG_PATH> <INPUT_PATH> <OUTPUT_NAME>` is the main entry point for OSMOX:
-
-```{sh}
-osmox run --help
-
-Usage: osmox run [OPTIONS] CONFIG_PATH INPUT_PATH OUTPUT_NAME
-
-Options:
-  -crs, --crs TEXT  crs string eg (default): 'epsg:27700' (UK grid)
-  -s, --single_use  split multi-activity facilities into multiple single-activity facilities
-  -l, --lazy        if filtered object already has a label, do not search for more (supresses multi-use but is faster)
-  --help            Show this message and exit.
-```
-
-Configs are described below. The `<INPUT_PATH>` should point to an OSM map dataset (`osm.xml` and `osm.pbf` are supported). The `<OUTPUT_NAME>` should be the desired name of the geojson output file i.e. `isle-of-man`.
-
-### Using Docker
-#### Build the image
-
-    docker build -t "osmox" .
-
-#### Running OSMOX in a container
-
-Once you have built the image, the only thing you need to do is add the path to the folder where your inputs are stored to the command, in order to mount that folder (i.e. give the container access to the data in this folder):
-
-    docker run -v DATA_FOLDER_PATH:/MOUNT_PATH osmox CONFIG_PATH INPUT_PATH OUTPUT_NAME -crs epsg:27700 -l
-
-For example, if your input data and config is stored on your machine in `/Users/user_1/mydata`, and this is also the directoy where you wish to place the outputs:
-
-    docker run -v /Users/user_1/mydata:/mnt/mydata osmox /mnt/mydata/example_config.json /mnt/mydata/isle-of-man-latest.osm.pbf isle-of-man -crs epsg:27700 -l
-
-
-## Options
-
-The most common option you will need to use is `crs`. The default CRS is British National Grid (BNG, or EPSG:27700), so if you are working outside the UK you should adjust this accordingly. Specifying a relevant CRS for your data is important if you would like to extract sensible units of measurement for distances and areas. If this isn't a concern, you can specify CRS as WGS-84 (`-crs epsg:4326`).
-
-OSMOX will return multi-use objects where applicable. For example, a building that contains both a restaurant and a shop can be labelled with `activities: "eating,shopping"`. This can make simple mapping of outputs quite complex, as there are many possible combinations of joined use. To work around this problem, the optionional flag `-s` or `--single_use` may be set to instead output unique objects for each activity. For example, for the above case, extracting two identical buildings, one with `activity: "eating"` and the other with `activity: "shopping"`.
-
-## Configs
-
-Configs are important, so we provide some examples in `mc/configs` and a validation method for when you start editing or building your own configs:
-
-```{sh}
-osmox validate <CONFIG PATH>
-```
-
-OSMOX features and associated configurations are described in the sections below.
-
-## Output
-
-After running `osmox run <CONFIG_PATH> <INPUT_PATH> <OUTPUT_NAME>` you should see something like the following (slowly if you are processing a large map) appear in your terminal:
-
-```{sh}
-Loading config from 'configs/config_NTS_UK.json'.
-Configured activities: ['education', 'home', 'medical', 'other', 'shop', 'transit', 'visit', 'work']
-INFO:osmox.main: Filtering all objects found in data/suffolk-latest.osm.pbf.
-INFO:osmox.main: Found 118544 buildings.
-INFO:osmox.main: Found 2661 nodes with valid tags.
-INFO:osmox.main: Found 5647 areas with valid tags.
-INFO:osmox.main: Assigning object tags.
-Progress: |██████████████████████████████████████████████████| 100.0% Complete
-INFO:osmox.main: Finished assigning tags: f{'existing': 49457, 'points': 711, 'areas': 54422, 'defaults': 13954}.
-INFO:osmox.main: Assigning object activities.
-Progress: |██████████████████████████████████████████████████| 100.0% Complete
-INFO:osmox.main: Assigning object features: ['units', 'levels', 'area', 'floor_area'].
-Progress: |██████████████████████████████████████████████████| 100.0% Complete
-INFO:osmox.main: Assigning distances to nearest transit.
-Progress: |██████████████████████████████████████████████████| 100.0% Complete
-INFO:osmox.main: Assigning distances to nearest education.
-Progress: |██████████████████████████████████████████████████| 100.0% Complete
-INFO:osmox.main: Assigning distances to nearest shop.
-Progress: |██████████████████████████████████████████████████| 100.0% Complete
-INFO:osmox.main: Assigning distances to nearest medical.
-Progress: |██████████████████████████████████████████████████| 100.0% Complete
-INFO:osmox.main: Writting objects to: suffolk2/suffolk_epsg_27700.geojson
-INFO:osmox.main: Reprojecting output to epsg:4326 (lat lon)
-INFO:osmox.main: Writting objects to: suffolk2/suffolk_epsg_4326.geojson
-INFO:osmox.main:Done.
-```
-
-Once completed, you will find OSMOX has outputted file(s) in `geojson` format in the same folder as the OSM input file. If you have specified a CRS, you will find two output files, named as follows:
-1)  `<OUTPUT_NAME>_<specified CRS name>.geojson`
-2)  `<OUTPUT_NAME>_epsg_4326.geojson`
-
-We generally refer to the outputs collectively as `facilities` and their properties as `features`. Note that each facility has a unique id, a number of features (depending on the configuration) and a point geometry. In the case of areas or polygons, such as buildings, the point represents the centroid.
-
-```{geojson}
-{
-    "id": "32653",
-    "type": "Feature",
-    "properties": {
-        "activities": "home",
-        "area": 72,
-        "distance_to_nearest_education": 298.3127023231315,
-        "floor_area": 144.0,
-        "id": 717793726,
-        "levels": 2.0,
-        "distance_to_nearest_medical": 614.1725582520537,
-        "distance_to_nearest_shop": 170.41317833861532,
-        "distance_to_nearest_transit": 157.88388248911602,
-        "units": 1
-        },
-    "geometry": {
-        "type": "Point",
-        "coordinates": [613632.5100411727, 242323.73560476975]
-    }
-}
-```
-
-In the quick start demo, we specified the coordinate reference system as `epsg:27700` (this is the default, but we specified it for visibility) so that distance- and area-based features would have sensible units (metres in this case). If extracting data from other regions, we would encourage using the local CRS.
-
-## Configuration
-
-### Definitions
-
-**OSMObjects** - objects extracted from OSM; can be points, lines or polygons; OSMObjects have features.
-
-**OSMFeatures** - OSMObjects have features, which typically include a key and value based on the [OSM wiki](https://wiki.openstreetmap.org/wiki/Map_features).
-
-### Primary Functionality
-
-The primary use case for OSMOX is for extracting a representation of places where people can do various activities ('education' or 'work' or 'shop' for example). This is done by applying a configured mapping to OSM tags:
-
-- **Filter** OSMObjects based on OSM tags (eg: select 'building:yes' objects). Filtered objects are defined in a `config.json`. For example, if we were interested in extracting education type `buildings`:
-
-```{json}
-{
-    "filter": {
-        "building": [
-            "kindergarden",
-            "school",
-            "university",
-            "college",
-            "yes"
-        ]
-    }, ...
-}
-```
-
-- **Activity Map** object activities based on OSM tags (eg: this building type 'university' is an education facility). Activity mapping is based on the same `config.json`, but we add a new section `activity_mapping`. For each OSM tag (a key such as `building` and a value such as `hotel`,) we map a list of activities:
-
-```{json}
-{
-    ...
-    "activity_mapping": {
-        "building": {
-            "hotel": ["work", "visit"],
-            "residential": ["home"]
-        }
-    }
-}
-```
-
-Because an OSM tag key is often sufficient to make an activity mapping, we allow use of `*` as "all":
-
-```{json}
-{
-    ...
-    "activity_mapping": {
-      ...
-        "office": {
-            "*": ["work"]
-        }
-    }
-}
-```
-
-Note that the filter controls the final objects that get extracted, but the activity mapping is more general. It is typical to map tags that are not included in the filter because these can be used by subsequent steps (such as inference) to assign activities where otherwise useful tags aren't included. There is no harm in over-specifying the mapping.
-
-These configs get very long - but we've supplied some full examples in the project.
-
-### Spatial Inference
-
-Because OSMObjects do not always contain useful tags, we also infer object tags based on spatial operations with surrounding tags.
-
-The most common use case for this is building objects that are simply tagged as `building:yes`. We use the below logic to infer useful tags, such as 'building:shop' or 'building:residential'.
-
-- **Contains** - If an OSMObject has no mappable tags (eg `building:yes`), tags are assigned based on the tags of objects that are contained within. For example, a building that contains an `amenity:shop` point, it is then tagged as `amenity:shop`.
-- **Within** - Where an OSMObject *still* does not have a useful OSM tag, the object tag will be assigned based on the tag of the object that it is contained within. The most common case is for untagged buildings to be assigned based on landuse objects. For example, a building within a `landuse:residential` area will be assigned with `building:residential`.
-
-In both cases we need to add the OSM tags we plan to use to the `activity_mapping` config, for example:
-
-```{json}
-{
-    ....
-    "activity_mapping": {
-        "building": {
-            "hotel": ["work", "visit"],
-            "residential": ["home"]
-        },
-        "amenity": {
-          "cafe": ["work", "eat"]
-        },
-        "landuse": {
-          "residential": ["home"]
-        }
-    }
-}
-```
-
-- **Default** - Where an OSM object *still* does not have a useful OSM tag, we can optionally apply defaults. Again, these are set in the config:
-
-```{json}
-{
-    ...
-    "default_tags": [["building", "residential"]],
-    ...
-}
-```
-
-### Feature Extraction
-
-Beyond simple assignment of human activities based on OSM tags, we also support the extraction of other features:
-
-- areas
-- floors
-- floor areas
-- units (eg residential units in a building)
-
-These can be configured as follows:
-
-```{json}
-{
-    ...
-    "features_config": ["units", "floors", "area", "floor_area"]
-    ...
-}
-```
-
-### Distance to Nearest Extraction
-
-OSMOX also supports calculating distance to nearest features based on object activities. For example, we can extract nearest distance to `transit`, `education`, `shop` and `medical` by adding the following to the config:
-
-```{json}
-{
-    ...
-    "distance_to_nearest": ["transit", "education", "shop", "medical"],
-    ...
-}
-```
-
-Note that the selected activities are based on the activity mapping config. Any activities should therefore be included in the activity mapping part of the config. You can use `osmox validate <CONFIG PATH>` to check if a config is correctly specified.
-
-### Fill in Missing Activities
-
-We have noted that it is not uncommon for some small areas to not have building objects, but to have an appropriate landuse area tagged as 'residential'.
-
-We therefore provide a very ad-hoc solution for filling in such areas with a grid of objects. This fill-in method only covers areas that do not have the required activities already within them.
-
-For example, given an area tagged as `landuse:residential` by OSM that does not contain any object of activity type `home`, the fill in method will add a grid of new objects tagged `building:house`. The new objects will also have activity type `home`, size `10 by 10` and be spaced at `25 by 25`:
-
-```{json}
-{
-    ...
-    "fill_missing_activities":
-        [
-            {
-                "area_tags": [["landuse", "residential"]],
-                "required_acts": ["home"],
-                "new_tags": [["building", "house"]],
-                "size": [10, 10],
-                "spacing": [25, 25]
-            }
-        ]
-}
-```
-
-![isle of man distance_to_nearest_transit](./readme_fixtures/activity-fill.png)
-*^ Example Isle of Man activity filling in action for a residential area without building locations.*
-
-Note that the selected activities are based on the activity mapping config. Any activities should therefore be included in the activity mapping part of the config. You can use `osmox validate <CONFIG PATH>` to check if a config is correctly specified.
-
-Multiple groups can also be defined, for example:
-
-```{json}
-{
-    ...
-    "fill_missing_activities":
-        [
-            {
-                "area_tags": [["landuse", "residential"]],
-                "required_acts": ["home"],
-                "new_tags": [["building", "house"]],
-                "size": [10, 10],
-                "spacing": [25, 25]
-            },
-            {
-                "area_tags": [["landuse", "forest"], ["landuse", "orchard"]],
-                "required_acts": ["tree_climbing", "glamping"],
-                "new_tags": [["amenity", "tree"], ["building", "tree house"]],
-                "size": [3, 3],
-                "spacing": [8, 8]
-            }
-        ]
-    ....
-}
-```
-
-## TODO
-
-- this is slow for sure - for national scale extractions we're talking many hours. There are some areas that can be sped up, some that will paralellize ok. But treating all this as premature until an output format is nailed down and there are a few more users
-- need tests for the use of all `*` in the config filter and mappings
-- move to toml/yaml configs (but maybe not the json is ok)
-- add zonal labelling (eg lsoa assignment)
-- perhaps add a sampling format (zone:act:{viables})
-- todo add support to keep original geometries
-- add .shp option
-- add other distance or similar type features, eg count of nearest neighbours
-- warning or feedback when trying to process really large datasets
+Then you can view the documentation in a browser at http://localhost:8000/.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,10 @@
+# CLI Reference
+
+This page provides documentation for our command line tools.
+
+::: mkdocs-click
+    :module: osmox.cli
+    :command: cli
+    :prog_name: osmox
+    :style: table
+    :depth: 1

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,228 @@
+
+# Configuration
+
+Configs are important, so we provide some examples in `configs` and a validation method for when you start editing or building your own configs:
+
+```shell
+osmox validate <CONFIG PATH>
+```
+
+OSMOX features and associated configurations are described in the sections below.
+
+!!! warning
+    These configs get very long - see the full examples in the `configs` to get an idea.
+
+## Definitions
+
+**OSMObjects** - objects extracted from OSM; can be points, lines or polygons; OSMObjects have features.
+
+**OSMFeatures** - OSMObjects have features, which typically include a key and value based on the [OSM wiki](https://wiki.openstreetmap.org/wiki/Map_features).
+
+## Primary Functionality
+
+The primary use case for OSMOX is for extracting a representation of places where people can do various activities ('education' or 'work' or 'shop' for example).
+This is done by applying a configured mapping to OSM tags:
+
+### Filter
+
+Filter OSMObjects based on OSM tags (eg: select 'building:yes' objects). Filtered objects are defined in a `config.json`.
+For example, if we were interested in extracting education type `buildings`:
+
+```json
+{
+    "filter": {
+        "building": [
+            "kindergarden",
+            "school",
+            "university",
+            "college",
+            "yes"
+        ]
+    }, ...
+}
+```
+
+### Activity Mapping
+
+Map object activities based on OSM tags (eg: this building type 'university' is an education facility).
+Activity mapping is based on the same `config.json`, but we add a new section `activity_mapping`. For each OSM tag (a key such as `building` and a value such as `hotel`,) we map a list of activities:
+
+```json
+{
+    ...
+    "activity_mapping": {
+        "building": {
+            "hotel": ["work", "visit"],
+            "residential": ["home"]
+        }
+    }
+}
+```
+
+Because an OSM tag key is often sufficient to make an activity mapping, we allow use of `*` as "all":
+
+```json
+{
+    ...
+    "activity_mapping": {
+    ...
+        "office": {
+            "*": ["work"]
+        }
+    }
+}
+```
+
+!!! note
+    The filter controls the final objects that get extracted, but the activity mapping is more general.
+    It is typical to map tags that are not included in the filter because these can be used by subsequent steps (such as inference) to assign activities where otherwise useful tags aren't included.
+    There is no harm in over-specifying the mapping.
+
+## Spatial Inference
+
+Because OSMObjects do not always contain useful tags, we also infer object tags based on spatial operations with surrounding tags.
+
+The most common use case for this is building objects that are simply tagged as `building:yes`.
+We use the below logic to infer useful tags, such as 'building:shop' or 'building:residential'.
+
+### Contains
+
+If an OSMObject has no mappable tags (eg `building:yes`), tags are assigned based on the tags of objects that are contained within.
+For example, a building that contains an `amenity:shop` point, it is then tagged as `amenity:shop`.
+
+### Within
+
+Where an OSMObject *still* does not have a useful OSM tag, the object tag will be assigned based on the tag of the object that it is contained within.
+The most common case is for untagged buildings to be assigned based on landuse objects.
+For example, a building within a `landuse:residential` area will be assigned with `building:residential`.
+
+In both cases we need to add the OSM tags we plan to use to the [activity_mapping](#activity-mapping) config, for example:
+
+```json
+{
+    ....
+    "activity_mapping": {
+        "building": {
+            "hotel": ["work", "visit"],
+            "residential": ["home"]
+        },
+        "amenity": {
+          "cafe": ["work", "eat"]
+        },
+        "landuse": {
+          "residential": ["home"]
+        }
+    }
+}
+```
+
+### Default
+
+Where an OSM object *still* does not have a useful OSM tag, we can optionally apply defaults.
+Again, these are set in the config:
+
+```json
+{
+    ...
+    "default_tags": [["building", "residential"]],
+    ...
+}
+```
+
+## Feature Extraction
+
+Beyond simple assignment of human activities based on OSM tags, we also support the extraction of other features:
+
+- areas
+- floors
+- floor areas
+- units (eg residential units in a building)
+
+These can be configured as follows:
+
+```json
+{
+    ...
+    "features_config": ["units", "floors", "area", "floor_area"]
+    ...
+}
+```
+
+## Distance to Nearest Extraction
+
+OSMOX also supports calculating distance to nearest features based on object activities.
+For example, we can extract nearest distance to `transit`, `education`, `shop` and `medical` by adding the following to the config:
+
+```json
+{
+    ...
+    "distance_to_nearest": ["transit", "education", "shop", "medical"],
+    ...
+}
+```
+
+Note that the selected activities are based on the activity mapping config.
+Any activities should therefore be included in the activity mapping part of the config.
+You can use `osmox validate <CONFIG PATH>` to check if a config is correctly specified.
+
+## Fill in Missing Activities
+
+We have noted that it is not uncommon for some small areas to not have building objects, but to have an appropriate landuse area tagged as 'residential'.
+
+We therefore provide a very ad-hoc solution for filling in such areas with a grid of objects.
+This infill method only covers areas that do not have the required activities already within them.
+
+For example, given an area tagged as `landuse:residential` by OSM that does not contain any object of activity type `home`, the fill in method will add a grid of new objects tagged `building:house`.
+The new objects will also have activity type `home`, size `10 by 10` and be spaced at `25 by 25`:
+
+```json
+{
+    ...
+    "fill_missing_activities":
+        [
+            {
+                "area_tags": [["landuse", "residential"]],
+                "required_acts": ["home"],
+                "new_tags": [["building", "house"]],
+                "size": [10, 10],
+                "spacing": [25, 25]
+            }
+        ]
+}
+```
+
+<figure>
+<img src="../resources/activity-fill.png", width="100%", style="background-color:white;", alt="Isle of man distance_to_nearest_transit">
+<figcaption>Example Isle of Man activity filling in action for a residential area without building locations.</figcaption>
+</figure>
+
+!!! note
+    The selected activities are based on the activity mapping config.
+    Any activities should therefore be included in the activity mapping part of the config.
+    You can use `osmox validate <CONFIG PATH>` to check if a config is correctly specified.
+
+Multiple groups can also be defined, for example:
+
+```json
+{
+    ...
+    "fill_missing_activities":
+        [
+            {
+                "area_tags": [["landuse", "residential"]],
+                "required_acts": ["home"],
+                "new_tags": [["building", "house"]],
+                "size": [10, 10],
+                "spacing": [25, 25]
+            },
+            {
+                "area_tags": [["landuse", "forest"], ["landuse", "orchard"]],
+                "required_acts": ["tree_climbing", "glamping"],
+                "new_tags": [["amenity", "tree"], ["building", "tree house"]],
+                "size": [3, 3],
+                "spacing": [8, 8]
+            }
+        ]
+    ....
+}
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,118 @@
+# Contributing
+
+osmox is an actively maintained and utilised project.
+
+## How to contribute
+
+to report issues, request features, or exchange with our community, just follow the links below.
+
+__Is something not working?__
+
+[:material-bug: Report a bug](https://github.com/arup-group/osmox/issues/new?template=BUG-REPORT.yml "Report a bug in osmox by creating an issue and a reproduction"){ .md-button }
+
+__Missing information in our docs?__
+
+[:material-file-document: Report a docs issue](https://github.com/arup-group/osmox/issues/new?template=DOCS.yml "Report missing information or potential inconsistencies in our documentation"){ .md-button }
+
+__Want to submit an idea?__
+
+[:material-lightbulb-on: Request a change](https://github.com/arup-group/osmox/issues/new?template=FEATURE-REQUEST.yml "Propose a change or feature request or suggest an improvement"){ .md-button }
+
+__Have a question or need help?__
+
+[:material-chat-question: Ask a question](https://github.com/arup-group/osmox/discussions "Ask questions on our discussion board and get in touch with our community"){ .md-button }
+
+## Developing osmox
+
+To find beginner-friendly existing bugs and feature requests you may like to start out with, take a look at our [good first issues](https://github.com/arup-group/osmox/contribute).
+
+## Known issues
+
+- OSMOX is slow - for national scale extractions we're talking many hours.
+There are some areas that can be sped up, some that will parallelize ok.
+But treating all this as premature until an output format is nailed down and there are a few more users.
+- We need tests for the use of all `*` in the config filter and mappings.
+- We want to move to yaml configs.
+- add zonal labelling (eg lsoa assignment).
+- perhaps add a sampling format (zone:act:{viables}).
+- Add support to keep original geometries.
+- add .shp option.
+- add other distance or similar type features, eg count of nearest neighbours.
+- warning or feedback when trying to process really large datasets.
+
+### Setting up a development environment
+
+To create a development environment for osmox, with all libraries required for development and quality assurance installed, it is easiest to install osmox using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
+
+1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
+1. Open the command line (or the "miniforge prompt" in Windows).
+1. Download (a.k.a., clone) the osmox repository: `git clone git@github.com:arup-group/osmox.git`
+1. Change into the `osmox` directory: `cd osmox`
+1. Create the osmox mamba environment: `mamba create -n osmox -c conda-forge -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt`
+1. Activate the osmox mamba environment: `mamba activate osmox`
+1. Install the osmox package into the environment, in editable mode and ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps -e .`
+
+All together:
+
+--8<-- "README.md:docs-install-dev"
+
+If installing directly with pip, you can install these libraries using the `dev` option, i.e., `pip install -e '.[dev]'`
+
+If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:
+
+- `pre-commit`: run `pre-commit install` in your command line to load inbuilt checks that will run every time you commit your changes.
+The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [PEP8 standard](https://peps.python.org/pep-0008/).
+You can also run these checks yourself at any time to ensure staged changes are clean by calling `pre-commit`.
+- `pytest` - run the unit test suite and check test coverage.
+
+### Rapid-fire testing
+
+The following options allow you to strip down the test suite to the bare essentials:
+1. You can avoid generating coverage reports, by adding the `--no-cov` argument: `pytest --no-cov`.
+1. By default, the tests run with up to two parallel threads, to increase this to e.g. 4 threads: `pytest -n4`.
+
+All together:
+
+``` shell
+pytest tests/ --no-cov -n4
+```
+
+!!! note
+
+    You cannot debug failing tests and have your tests run in parallel, you will need to set `-n0` if using the `--pdb` flag
+
+### Memory profiling
+
+!!! note
+    When you open a pull request (PR), one of the GitHub actions will run memory profiling for you.
+    This means you don't *have* to do any profiling locally.
+    However, if you can, it is still good practice to do so as you will catch issues earlier.
+
+osmox can be memory intensive; we like to ensure that any development to the core code does not exacerbate this.
+If you are running on a UNIX device (i.e., **not** on Windows), you can test whether any changes you have made adversely impact memory and time performance as follows:
+
+1. Install [memray](https://bloomberg.github.io/memray/index.html) in your `osmox` mamba environment: `mamba install memray pytest-memray`.
+2. Run the memory profiling integration test: `pytest -p memray -m "high_mem" --no-cov`.
+3. Optionally, to visualise the memory allocation, run `pytest -p memray -m "high_mem" --no-cov --memray-bin-path=[my_path] --memray-bin-prefix=[my_prefix]` - where you must define `[my_path]` and `[my_prefix]` - followed by `memray flamegraph [my_path]/[my_prefix]-tests-test_100_memory_profiling.py-test_mem.bin`.
+You will then find the HTML report at `[my_path]/memray-flamegraph-[my_prefix]-tests-test_100_memory_profiling.py-test_mem.html`.
+
+All together:
+
+``` shell
+mamba install memray pytest-memray
+pytest -p memray -m "high_mem" --no-cov --memray-bin-path=[my_path] --memray-bin-prefix=[my_prefix]
+memray flamegraph [my_path]/[my_prefix]-tests-test_100_memory_profiling.py-test_mem.bin
+```
+
+For more information on using memray, refer to their [documentation](https://bloomberg.github.io/memray/index.html).
+
+## Updating the project when the template updates
+
+This project has been built with [cruft](https://cruft.github.io/cruft/) based on the [Arup Cookiecutter template](https://github.com/arup-group/cookiecutter-pypackage).
+When changes are made to the base template, they can be merged into this project by running `cruft update` from the  `osmox` mamba environment.
+
+You may be prompted to do this when you open a Pull Request, if our automated checks identify that the template is newer than that used in the project.
+
+## Submitting changes
+
+--8<-- "CONTRIBUTING.md:docs"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+<!--
+By default, the index will be a copy of your repository README preamble.
+You can replace this cross-reference or append/prepend to it by updating this page.
+-->
+
+--8<-- "README.md:docs"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,23 @@
+
+# Installation
+
+## Setting up a user environment
+
+As a `osmox` user, it is easiest to install using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
+
+1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
+1. Open the command line (or the "miniforge prompt" in Windows).
+1. Create the osmox mamba environment: `mamba create -n osmox -c conda-forge -c city-modelling-lab osmox`
+1. Activate the osmox mamba environment: `mamba activate osmox`
+
+All together:
+
+--8<-- "README.md:docs-install-user"
+
+## Setting up a development environment
+
+The install instructions are slightly different to create a development environment compared to a user environment:
+
+--8<-- "README.md:docs-install-dev"
+
+For more detailed installation instructions specific to developing the osmox codebase, see our [development documentation][setting-up-a-development-environment].

--- a/docs/osmox_run.md
+++ b/docs/osmox_run.md
@@ -1,0 +1,112 @@
+
+# OSMOX Run
+
+`#!shell osmox run <CONFIG_PATH> <INPUT_PATH> <OUTPUT_NAME>` is the main entry point for OSMOX.
+Available options are detailed in on our [Command Line Interface reference page](api/cli.md).
+
+Configuration options are described in a [separate page](config.md).
+The `<INPUT_PATH>` should point to an OSM map dataset (`osm.xml` and `osm.pbf` are supported).
+The `<OUTPUT_NAME>` should be the desired name of the geojson output file i.e. `isle-of-man`.
+
+## Using Docker
+
+### Build the image
+
+```shell
+docker build -t "osmox" .
+```
+
+### Running OSMOX in a container
+
+Once you have built the image, the only thing you need to do is add the path to the folder where your inputs are stored to the command, in order to mount that folder (i.e. give the container access to the data in this folder):
+
+```shell
+docker run -v DATA_FOLDER_PATH:/MOUNT_PATH osmox CONFIG_PATH INPUT_PATH OUTPUT_NAME -crs epsg:27700 -l
+```
+
+For example, if your input data and config is stored on your machine in `/Users/user_1/mydata`, and this is also the directory where you wish to place the outputs:
+
+```shell
+docker run -v /Users/user_1/mydata:/mnt/mydata osmox /mnt/mydata/example_config.json /mnt/mydata/isle-of-man-latest.osm.pbf isle-of-man -crs epsg:27700 -l
+```
+
+## Options
+
+The most common option you will need to use is `crs`.
+The default CRS is British National Grid (BNG, or EPSG:27700), so if you are working outside the UK you should adjust this accordingly.
+Specifying a relevant CRS for your data is important if you would like to extract sensible units of measurement for distances and areas.
+If this isn't a concern, you can specify CRS as WGS-84 (`-crs epsg:4326`).
+
+OSMOX will return multi-use objects where applicable.
+For example, a building that contains both a restaurant and a shop can be labelled with `activities: "eating,shopping"`.
+This can make simple mapping of outputs quite complex, as there are many possible combinations of joined use.
+To work around this problem, the optional flag `-s` or `--single_use` may be set to instead output unique objects for each activity.
+For example, for the above case, extracting two identical buildings, one with `activity: "eating"` and the other with `activity: "shopping"`.
+
+## Output
+
+After running `osmox run <CONFIG_PATH> <INPUT_PATH> <OUTPUT_NAME>` you should see something like the following (slowly if you are processing a large map) appear in your terminal:
+
+```shell
+Loading config from 'configs/config_NTS_UK.json'.
+Configured activities: ['education', 'home', 'medical', 'other', 'shop', 'transit', 'visit', 'work']
+INFO:osmox.main: Filtering all objects found in data/suffolk-latest.osm.pbf.
+INFO:osmox.main: Found 118544 buildings.
+INFO:osmox.main: Found 2661 nodes with valid tags.
+INFO:osmox.main: Found 5647 areas with valid tags.
+INFO:osmox.main: Assigning object tags.
+Progress: |██████████████████████████████████████████████████| 100.0% Complete
+INFO:osmox.main: Finished assigning tags: f{'existing': 49457, 'points': 711, 'areas': 54422, 'defaults': 13954}.
+INFO:osmox.main: Assigning object activities.
+Progress: |██████████████████████████████████████████████████| 100.0% Complete
+INFO:osmox.main: Assigning object features: ['units', 'levels', 'area', 'floor_area'].
+Progress: |██████████████████████████████████████████████████| 100.0% Complete
+INFO:osmox.main: Assigning distances to nearest transit.
+Progress: |██████████████████████████████████████████████████| 100.0% Complete
+INFO:osmox.main: Assigning distances to nearest education.
+Progress: |██████████████████████████████████████████████████| 100.0% Complete
+INFO:osmox.main: Assigning distances to nearest shop.
+Progress: |██████████████████████████████████████████████████| 100.0% Complete
+INFO:osmox.main: Assigning distances to nearest medical.
+Progress: |██████████████████████████████████████████████████| 100.0% Complete
+INFO:osmox.main: Writing objects to: suffolk2/suffolk_epsg_27700.geojson
+INFO:osmox.main: Reprojecting output to epsg:4326 (lat lon)
+INFO:osmox.main: Writing objects to: suffolk2/suffolk_epsg_4326.geojson
+INFO:osmox.main:Done.
+```
+
+Once completed, you will find OSMOX has output file(s) in `geojson` format in the same folder as the OSM input file.
+If you have specified a CRS, you will find two output files, named as follows:
+
+1. `<OUTPUT_NAME>_<specified CRS name>.geojson`
+2. `<OUTPUT_NAME>_epsg_4326.geojson`
+
+We generally refer to the outputs collectively as `facilities` and their properties as `features`.
+Note that each facility has a unique id, a number of features (depending on the configuration) and a point geometry.
+In the case of areas or polygons, such as buildings, the point represents the centroid.
+
+```json
+{
+    "id": "32653",
+    "type": "Feature",
+    "properties": {
+        "activities": "home",
+        "area": 72,
+        "distance_to_nearest_education": 298.3127023231315,
+        "floor_area": 144.0,
+        "id": 717793726,
+        "levels": 2.0,
+        "distance_to_nearest_medical": 614.1725582520537,
+        "distance_to_nearest_shop": 170.41317833861532,
+        "distance_to_nearest_transit": 157.88388248911602,
+        "units": 1
+        },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [613632.5100411727, 242323.73560476975]
+    }
+}
+```
+
+In the [quick start demo](quick_start.md), we specified the coordinate reference system as `epsg:27700` (this is the default, but we specified it for visibility) so that distance- and area-based features would have sensible units (metres in this case).
+If extracting data from other regions, we would encourage using the local CRS.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,3 @@
+<!-- Directory to customise the mkdocs "material" theme. See [here](https://squidfunk.github.io/mkdocs-material/customization) for more detail. -->
+
+{% extends "base.html" %}

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,0 +1,55 @@
+# Quick Start
+
+Extract `home`, `work`, `education`, `shop` and various other activity locations ("facilities") for the Isle of Man, using the following steps (paths is given from OSMOX project root):
+
+First download `isle-of-man-latest.osm.pbf` from [geofabrik](https://download.geofabrik.de/europe/isle-of-man.html) and place in an `example` directory.
+Then run:
+
+```sh
+osmox run configs/example.json example/isle-of-man-latest.osm.pbf isle-of-man -crs epsg:27700 -l
+```
+
+After about 30 seconds, you should find the outputs in geojson format in the same `example` directory as your OSM input file.
+The geojson file contains locations for the extracted facilities, and each facility includes a number of features with coordinates given in WGS-84 (EPSG:4326) coordinate reference system (CRS), so that they can be quickly inspected using [geopandas](https://geopandas.org/en/stable) or equivalent.
+
+`-l` is short for `--lazy` which helps osmox run a little faster.
+
+```json
+{
+    "type": "FeatureCollection",
+    "features": [
+        ...
+        {
+        "id": "13589",
+        "type": "Feature",
+        "properties": {
+            "activities": "home",
+            "area": 196,
+            "distance_to_nearest_education": 816.4434678355371,
+            "distance_to_nearest_medical": 366.81198701080626,
+            "distance_to_nearest_shop": 133.12877450643526,
+            "distance_to_nearest_transit": 122.33125535187033,
+            "floor_area": 392.0,
+            "id": 1869954720,
+            "levels": 2.0,
+            "units": 1
+            },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [220894.60596542264, 467332.85704661923]
+            }
+        },
+        ...
+```
+
+<figure>
+<img src="../resources/floor-areas.png", width="100%", style="background-color:white;", alt="Isle of man floor areas">
+<figcaption>Isle of Man facility `floor_area` feature. Approximated based on polygon areas and floor labels or sensible defaults.</figcaption>
+</figure>
+
+<figure>
+<img src="../resources/activities.png", width="100%", style="background-color:white;", alt="Isle of man activities">
+<figcaption>Isle of Man `activities` feature.
+For simulations we use this information to control what agents can do where, but this is also a good disaggregate proxy for land-use.
+In this example, blue areas are residential, orange commercial and brown is other work places.</figcaption>
+</figure>

--- a/docs/static/extras.css
+++ b/docs/static/extras.css
@@ -1,0 +1,10 @@
+/* API indentation. */
+div.doc-contents:not(.first) {
+  padding-left: 25px;
+  border-left: 4px solid rgba(230, 230, 230);
+}
+
+/* Allow tables to be horizontally scrollable. */
+.md-typeset__scrollwrap {
+  overflow-x: auto;
+}

--- a/docs/static/hooks.py
+++ b/docs/static/hooks.py
@@ -1,0 +1,147 @@
+import tempfile
+from pathlib import Path
+
+import mkdocs.plugins
+from mkdocs.structure.files import File
+
+TEMPDIR = tempfile.TemporaryDirectory()
+# Add to this list if you want to ignore any other source files from the documentation API reference
+API_FILES_TO_IGNORE = ["cli.py"]
+
+
+# Bump priority to ensure files are moved before jupyter notebook conversion takes place
+@mkdocs.plugins.event_priority(50)
+def on_files(files: list, config: dict, **kwargs):
+    """Link (1) top-level files to mkdocs files and (2) generate the python API documentation."""
+    for file in Path("./resources").glob("**/*.*"):
+        files.append(_new_file(file, config))
+    files.append(_new_file(Path("./CHANGELOG.md"), config))
+
+    api_nav = _api_gen(files, config)
+    _update_nav(api_nav, config)
+
+    return files
+
+
+def _new_file(path: Path, config: dict, src_dir: str = ".") -> File:
+    """Link a file out in the wilderness to a filename in the documentation directory hierarchy.
+
+    Args:
+        path (Path):
+            Path (relative to "src_dir") to file that you want to bring into the documentation directory.
+            In the documentation directory, this same path with apply (e.g., `[src_dir]/path/to/file.md` will become `[docs_dir]/path/to/file.md`)
+        config (dict): mkdocs config dictionary.
+        src_dir (str, optional):
+            Path in which to find the file you want to bring into the docs directory. Defaults to ".".
+
+    Returns:
+        File: mkdocs object that links your file to the docs directory, ready to be added to the mkdocs file list.
+    """
+    return File(
+        path=path,
+        src_dir=src_dir,
+        dest_dir=config["site_dir"],
+        use_directory_urls=config["use_directory_urls"],
+    )
+
+
+def _api_gen(files: list, config: dict) -> dict:
+    """Project Python API generator
+
+    Args:
+        files (list): mkdocs file list.
+        config (dict): mkdocs config dictionary.
+
+    Returns:
+        dict: Python API navigation tree, to add into the mkdocs `nav` tree.
+    """
+    source_dir = Path(config["watch"][0])
+    source_file = source_dir.parts[-1]
+    api_nav: dict = {"top_level": []}
+    for filepath in sorted(source_dir.rglob("[!_]*.py")):
+        rel_filepath = filepath.relative_to(source_dir)
+        if rel_filepath.as_posix() in API_FILES_TO_IGNORE:
+            continue
+        file = _py_to_md(source_file / rel_filepath, api_nav, config)
+        files.append(file)
+    return api_nav
+
+
+def _py_to_md(filepath: Path, api_nav: dict, config: dict) -> File:
+    """Create a markdown file for the API documentation for a given python file in the package source directory.
+
+    Markdown files are stored in a temporary directory, which will be cleaned after mkdocs has finished building the docs.
+
+    Args:
+        filepath (Path): Path to python file relative to the package source code directory.
+        api_nav (dict): Nested dictionary to fill with mkdocs navigation entries.
+        config (Config): mkdocs config dictionary.
+    Returns:
+        File: mkdocs object that links the temp file to the docs directory, ready to be added to the mkdocs file list.
+    """
+    module_parts = filepath.with_suffix("").parts
+
+    module_name = ".".join(module_parts)
+
+    api_file = "reference" / filepath.with_suffix(".md")
+    api_full_filepath = Path(TEMPDIR.name) / api_file
+    api_full_filepath.parent.mkdir(exist_ok=True, parents=True)
+    api_full_filepath.write_text(f"::: {module_name}")
+
+    nav_component = {module_name: api_file.as_posix()}
+    if len(module_parts) > 2:  # i.e., in a nested directory
+        parent_module = ".".join(module_parts[:2])
+        if parent_module not in api_nav:
+            api_nav[parent_module] = [nav_component]
+        else:
+            api_nav[parent_module].append(nav_component)
+    else:
+        api_nav["top_level"].append(nav_component)
+    return _new_file(api_file, config, TEMPDIR.name)
+
+
+def _update_nav(api_nav: dict, config: dict) -> None:
+    """Update mkdocs navigation tree with the Python API sub-tree.
+
+    Mkdocs navigation is composed of lists of dictionaries.
+    Lists nesting defines navigation nesting, dictionary keys are the page names, and values are the pointers to markdown files.
+
+    Args:
+        api_nav (dict): Python API navigation tree.
+        config (dict): mkdocs config dictionary (in which `nav` can be found).
+    """
+
+    api_reference_nav = {
+        "Python API": [*api_nav.pop("top_level"), *[{k: v} for k, v in api_nav.items()]]
+    }
+    _get_nav_list(config["nav"], "Reference").append(api_reference_nav)
+
+
+def _get_nav_list(nav: list[dict | str], ref: str) -> list:
+    """Get navigation entry sub-page list.
+    Navigation list entries can be dictionaries or strings.
+    Sub-list entries can then also be dictionaries or strings. E.g.,
+
+    ```python
+    [{"Page Title": ["sub-page-1", {"Sub-Page-2 Title": "sub-page-2"}, ...], ...}]
+    ```
+
+    Args:
+        nav (list[dict  |  str]): MKdocs `nav` config entry.
+        ref (str): Page title reference to return the sub-list of.
+
+    Returns:
+        list: Nav sub-list linked to `ref`.
+    """
+    nav_ref = [idx for idx in nav if isinstance(idx, dict) and set(idx.keys()) == {ref}][0]
+    return nav_ref[ref]
+
+
+@mkdocs.plugins.event_priority(-100)
+def on_post_build(**kwargs):
+    """After mkdocs has finished building the docs, remove the temporary directory of markdown files.
+
+    Args:
+        config (Config): mkdocs config dictionary (unused).
+    """
+    TEMPDIR.cleanup()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,74 @@
+site_name: OSMOX
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - quick_start.md
+  - osmox_run.md
+  - config.md
+  - Contributing: contributing.md
+  - Changelog: CHANGELOG.md
+  - Reference:
+    - Command line interface: api/cli.md
+theme:
+  name: material
+  custom_dir: docs/overrides
+  features:
+    - navigation.indexes
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+repo_url: https://github.com/arup-group/osmox/
+site_dir: .docs
+markdown_extensions:
+  - admonition
+  - attr_list
+  - mkdocs-click
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      clickable_checkbox: true
+  - toc:
+      permalink: "#"
+      toc_depth: 3
+hooks:
+  - docs/static/hooks.py
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            docstring_section_style: spacy
+            show_bases: true
+            filters:
+              - "!^_"
+            merge_init_into_class: true
+            show_if_no_docstring: true
+            signature_crossrefs: true
+            show_root_toc_entry: false
+            show_signature_annotations: false
+          paths: [src]
+          import:
+            - https://docs.python.org/3/objects.inv
+            - https://pandas.pydata.org/docs/objects.inv
+            - https://shapely.readthedocs.io/en/stable/objects.inv
+            - https://geopandas.org/en/stable/objects.inv
+watch:
+  - src/osmox
+extra_css:
+  - static/extras.css
+extra:
+  version:
+    provider: mike

--- a/src/osmox/cli.py
+++ b/src/osmox/cli.py
@@ -108,7 +108,7 @@ def run(config_path, input_path, output_name, crs, single_use, lazy):
     gdf = handler.geodataframe(single_use=single_use)
 
     path = path_leaf(input_path) / f"{output_name}_{crs.replace(':', '_')}.geojson"
-    logger.info(f" Writting objects to: {path}")
+    logger.info(f" Writing objects to: {path}")
     with open(path, "w") as file:
         file.write(gdf.to_json())
 
@@ -116,7 +116,7 @@ def run(config_path, input_path, output_name, crs, single_use, lazy):
         logger.info(" Reprojecting output to epsg:4326 (lat lon)")
         gdf.to_crs("epsg:4326", inplace=True)
         path = path_leaf(input_path) / f"{output_name}_epsg_4326.geojson"
-        logger.info(f" Writting objects to: {path}")
+        logger.info(f" Writing objects to: {path}")
         with open(path, "w") as file:
             file.write(gdf.to_json())
 


### PR DESCRIPTION
I've moved the content of the README to the osmox documentation site that will be built and released to https://arup-group.github.io/osmox after this PR is merged.

@val-ismaili would be worth checking out the content locally by installing the osmox dev environment (using the new install instructions) and running `mkdocs serve` in the command line. Then you can browse a local build of the docs.

I've tried splitting up the existing README into separate pages, but am not the best person to decide on the parcelling of content into different sections!