### PR TITLE
Add docs build CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Build docs
+
+on:
+  push:
+    branches:
+      - "**"
+    paths-ignore:
+      - tests/**
+
+jobs:
+  docs-test:
+    if: github.ref != 'refs/heads/main'
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    with:
+      deploy_type: test
+
+  docs-update-latest:
+    permissions:
+      contents: write
+    if: github.ref == 'refs/heads/main'
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    with:
+      deploy_type: update_latest
+
+  slack-notify-ci-failure:
+    needs: [docs-test, docs-update-latest]
+    if: always() && contains(needs.*.result, 'failure')
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@main
+    secrets: inherit
+    with:
+      result: 'failure'
+      channel: city-modelling-feeds
+      message: Docs Build


### PR DESCRIPTION
Realised that I missed the docs build CI in #40 . This PR adds it in and will actually start the `gh-pages` branch in the repo to store the built documentation.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Tests added to cover contribution
- [ ] Documentation updated
