### PR TITLE
Fix cookiecuttered CI builds

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -13,6 +13,7 @@
       "package_name": "osmox",
       "module_name": "osmox",
       "project_short_description": "A tool for extracting locations and features from OpenStreetMap (OSM) data.",
+      "project_visibility": "public",
       "upload_pypi_package": "y",
       "upload_conda_package": "y",
       "conda_channel": "city-modelling-lab",

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/arup-group/cookiecutter-pypackage",
-  "commit": "b7724521f898ab28f541d492aff8e2be2ed76a01",
+  "commit": "2c07547902fe10839dcfb8031ef612bf7ca4f23f",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -14,13 +14,15 @@
       "module_name": "osmox",
       "project_short_description": "A tool for extracting locations and features from OpenStreetMap (OSM) data.",
       "project_visibility": "public",
-      "upload_pypi_package": "y",
+      "upload_pip_package": "n",
       "upload_conda_package": "y",
+      "upload_aws_image": "n",
       "conda_channel": "city-modelling-lab",
       "command_line_interface": "y",
       "create_docker_file": "y",
       "create_author_file": "n",
       "create_jupyter_notebook_directory": "n",
+      "check_docs_accessibility_in_CI": "n",
       "open_source_license": "MIT license",
       "_template": "https://github.com/arup-group/cookiecutter-pypackage"
     }

--- a/.cruft.json
+++ b/.cruft.json
@@ -14,7 +14,7 @@
       "module_name": "osmox",
       "project_short_description": "A tool for extracting locations and features from OpenStreetMap (OSM) data.",
       "project_visibility": "public",
-      "upload_pip_package": "n",
+      "upload_pip_package": "y",
       "upload_conda_package": "y",
       "upload_aws_image": "n",
       "conda_channel": "city-modelling-lab",

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Documentation: https://EditorConfig.org
+# Inspired by Calliope .editorconfig file
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[LICENSE]
+insert_final_newline = false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Fixes # .
 
-## Checklist
+# Checklist
 
 Any checks which are not relevant to the PR can be pre-checked by the PR creator.
 All others should be checked by the reviewer(s).

--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -14,30 +14,8 @@ on:
 
 jobs:
   test:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.0
     with:
       os: ubuntu-latest
       py3version: "12"
       lint: false
-
-  aws-pre-check:
-    runs-on: ubuntu-latest
-    outputs:
-      aws-secrets-exist: ${{ steps.secret-checker.outputs.SECRETS_EXIST }}
-    steps:
-      - id: secret-checker
-        name: 'Check secret access for fast fail'
-        run: |
-          echo "SECRETS_EXIST=$AWS_SECRETS_EXIST" >> $GITHUB_OUTPUT
-          echo "SECRETS_EXIST=$AWS_SECRETS_EXIST" >> $GITHUB_STEP_SUMMARY
-        env:
-          AWS_SECRETS_EXIST: ${{ secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '' && secrets.AWS_S3_CODE_BUCKET != '' }}
-
-  aws-upload:
-    needs: [test, aws-pre-check]
-    if: always() && needs.test.result == 'success' && needs.aws-pre-check.outputs.aws-secrets-exist == 'true'
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@main
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
     needs: get-date
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.1
     with:
       os: ubuntu-latest
       py3version: "12"
@@ -25,7 +25,7 @@ jobs:
   slack-notify-ci:
     needs: test
     if: always()
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@v1.1.1
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
     with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,6 @@ jobs:
     permissions:
       contents: write
     if: github.ref == 'refs/heads/main'
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.1
     with:
       deploy_type: update_latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,14 +3,40 @@ name: Build docs
 on:
   push:
     branches:
-      - "**"
+      - main
+
+  pull_request:
+    branches:
+      - main
     paths-ignore:
       - tests/**
+      - ".github/**/*"
+      - "!.github/workflows/docs.yml"
+
 
 jobs:
-  docs-test:
+  docs-lint:
     if: github.ref != 'refs/heads/main'
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: markdown-link-check
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: linkcheck.json
+    - if: github.event.repository.private
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: pymarkdown --all-files
+    - if: github.event.repository.private
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: codespell --all-files
+
+  docs-test:
+    needs: [docs-lint]
+    if: github.ref != 'refs/heads/main'
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.0
     with:
       deploy_type: test
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,15 +11,26 @@ on:
       - CONTRIBUTING.md
       - docs/**
       - mkdocs.yml
+      - ".github/**/*"
+      - "!.github/workflows/pr-ci.yml"
 
 jobs:
+  lint:
+    if: github.event.repository.private
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: pre-commit/action@v3.0.1
+
   test:
+    needs: lint
+    if: always() && (needs.lint.result  == 'success' || needs.lint.result  == 'skipped')
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         py3version: ["10", "12"]
       fail-fast: false
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.0
     with:
       os: ${{ matrix.os }}
       py3version: ${{ matrix.py3version }}

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -39,7 +39,7 @@ jobs:
       upload_to_codecov: false
 
   test-coverage:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.1
     with:
       os: ubuntu-latest
       py3version: "12"
@@ -48,4 +48,4 @@ jobs:
       upload_to_codecov: true
 
   cruft-check:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/template-check.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/template-check.yml@v1.1.1

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,20 +7,13 @@ on:
 
 jobs:
   conda-build:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@v1.1.0
     secrets:
       ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
     with:
       package_name: osmox
       environment: pre-release
+      destination: pypi
 
   
-  pip-build:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@main
-    secrets:
-      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-    with:
-      package_name: osmox
-      environment: pre-release
-
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,28 +6,20 @@ on:
 
 jobs:
   conda-upload:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@v1.1.0
     secrets:
       ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
     with:
       package_name: osmox
       build_workflow: pre-release.yml
       environment: release
+      destination: anaconda
 
   
-  pip-upload:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@main
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-    with:
-      package_name: osmox
-      build_workflow: pre-release.yml
-      environment: release
-
   
   docs-stable:
     permissions:
       contents: write
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.0
     with:
       deploy_type: update_stable

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ mike-*.yml
 
 # Repository-specific
 example/
+.python-version

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,24 @@
+{
+  "defaults": {
+    "reporters": [
+        "cli",
+      [
+        "pa11y-ci-reporter-html",
+        { "destination": "./reports/pa11y", "includeZeroIssues": false }
+      ]
+    ],
+    "timeout": 100000,
+    "wait": 2000,
+    "ignore": ["color-contrast"],
+    "runners": [
+      "htmlcs", "axe"
+    ],
+    "hideElements": "[id^='__codelineno'], .md-search__form, #__toc, clipboard-copy"
+  },
+  "standard": "WCAG2AA",
+  "comments": [
+    "Ignoring color-contrast due to https://github.com/pa11y/pa11y/issues/697.",
+    "Hiding `clipboard-copy` until https://github.com/danielfrg/mkdocs-jupyter/pull/206 is merged.",
+    "Hiding `[id^='__codelineno'], .md-search__form, #__toc` due to known false positives in mkdocs-material: https://github.com/squidfunk/mkdocs-material/discussions/4102"
+  ]
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -61,55 +61,136 @@ If installing directly with pip, you can install these libraries using the `dev`
 If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:
 
 - `pre-commit`: run `pre-commit install` in your command line to load inbuilt checks that will run every time you commit your changes.
-The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [PEP8 standard](https://peps.python.org/pep-0008/).
-You can also run these checks yourself at any time to ensure staged changes are clean by calling `pre-commit`.
+  The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [PEP8 standard](https://peps.python.org/pep-0008/).
+  You can also run these checks yourself at any time to ensure staged changes are clean by calling `pre-commit`.
 - `pytest` - run the unit test suite and check test coverage.
+
+
 
 ### Rapid-fire testing
 
 The following options allow you to strip down the test suite to the bare essentials:
+
+
 1. You can avoid generating coverage reports, by adding the `--no-cov` argument: `pytest --no-cov`.
-1. By default, the tests run with up to two parallel threads, to increase this to e.g. 4 threads: `pytest -n4`.
-
-All together:
-
-``` shell
-pytest tests/ --no-cov -n4
-```
-
-!!! note
-
-    You cannot debug failing tests and have your tests run in parallel, you will need to set `-n0` if using the `--pdb` flag
 
 ### Memory profiling
 
 !!! note
     When you open a pull request (PR), one of the GitHub actions will run memory profiling for you.
-    This means you don't *have* to do any profiling locally.
+    This means you don't *have- to do any profiling locally.
     However, if you can, it is still good practice to do so as you will catch issues earlier.
 
 osmox can be memory intensive; we like to ensure that any development to the core code does not exacerbate this.
-If you are running on a UNIX device (i.e., **not** on Windows), you can test whether any changes you have made adversely impact memory and time performance as follows:
+If you are running on a UNIX device (i.e., **not*- on Windows), you can test whether any changes you have made adversely impact memory and time performance as follows:
 
-1. Install [memray](https://bloomberg.github.io/memray/index.html) in your `osmox` mamba environment: `mamba install memray pytest-memray`.
-2. Run the memory profiling integration test: `pytest -p memray -m "high_mem" --no-cov`.
-3. Optionally, to visualise the memory allocation, run `pytest -p memray -m "high_mem" --no-cov --memray-bin-path=[my_path] --memray-bin-prefix=[my_prefix]` - where you must define `[my_path]` and `[my_prefix]` - followed by `memray flamegraph [my_path]/[my_prefix]-tests-test_100_memory_profiling.py-test_mem.bin`.
-You will then find the HTML report at `[my_path]/memray-flamegraph-[my_prefix]-tests-test_100_memory_profiling.py-test_mem.html`.
+1. Install [memray](https://bloomberg.github.io/memray/index.html) in your `osmox` conda environment: `conda install memray pytest-memray`.
+1. Run the memory profiling integration test: `pytest -p memray -m "high_mem" --no-cov`.
+1. Optionally, to visualise the memory allocation, run `pytest -p memray -m "high_mem" --no-cov --memray-bin-path=[my_path] --memray-bin-prefix=[my_prefix]` - where you must define `[my_path]` and `[my_prefix]` - followed by `memray flamegraph [my_path]/[my_prefix]-tests-test_100_memory_profiling.py-test_mem.bin`.
+   You will then find the HTML report at `[my_path]/memray-flamegraph-[my_prefix]-tests-test_100_memory_profiling.py-test_mem.html`.
 
 All together:
 
 ``` shell
-mamba install memray pytest-memray
+conda install memray pytest-memray
 pytest -p memray -m "high_mem" --no-cov --memray-bin-path=[my_path] --memray-bin-prefix=[my_prefix]
 memray flamegraph [my_path]/[my_prefix]-tests-test_100_memory_profiling.py-test_mem.bin
 ```
 
 For more information on using memray, refer to their [documentation](https://bloomberg.github.io/memray/index.html).
 
+## Documentation
+
+With any contribution, you may need to update / add to the documentation (in the `docs` directory).
+We use [MkDocs](https://www.mkdocs.org/) and the [Material](https://squidfunk.github.io/mkdocs-material/) theme to build and render our documentation, meaning you can write your documentation in Markdown files.
+
+Here are some use-cases that you may come across in which you are considering updating the documentation:
+
+??? question "I have updated the README.md"
+
+    We pipe sections of the README over to the documentation automatically.
+    If you put your changes between the commented lines `:::md <!--- --8<-- [start:docs] -->` and `:::md <!--- --8<-- [end:docs] -->` it will find its way to the documentation homepage.
+
+??? question annotate "I want to add a new page"
+
+    Add a Markdown file to the top-level in `docs`, e.g. `docs/my-page.md`.
+    Then, add a reference to that file within the `nav` key in `mkdocs.yml`, e.g.:
+
+    ```yaml
+    nav:
+    - Home: index.md
+    - Installation: installation.md
+    - Getting started: getting_started.md
+    - My Page: my-page.md
+    ```
+
+    You can also just rely on your document header to define the name in the navigation:
+    `my-page.md`
+
+    ```md
+    # My Page
+    ...
+    ```
+
+    `mkdocs.yml`
+
+    ```yaml
+    nav:
+    ...
+    - my-page.md
+    ...
+    ```
+
+??? question "I have a new example notebook"
+
+    If the project is set up to include process examples (see `.cruft.json` option `create_jupyter_notebook_directory`),
+    then you can just add a [Jupyter notebook](https://jupyter.org/) to the `examples` directory and it will automatically render in the documentation under `Examples`.
+
+??? question "I want to add images to my docs"
+
+    You should add any new images, whether you reference them in a Markdown page or in an example notebook, to the `resources/` directory.
+    Within your Markdown, you will be able to reference these as follows:
+
+    ``` html
+    <figure>
+    <img src="../resources/filename.png", width="100%", style="background-color:white;", alt="accessible alternative text">
+    <figcaption>My caption.</figcaption>
+    </figure>
+    ```
+
+    Or:
+
+    ``` md
+    ![accessible alternative text](../resources/filename.png)
+    ```
+
+    The first approach gives you a bit more power, including having a figure caption.
+
+??? question "I want to update the CLI/Python API docs"
+
+    As with example notebooks, we update these pages automatically.
+    So, if you've added content within your project (a new script, a new CLI function), you will see them in your next iteration of the documentation.
+
+??? question "I want to automatically process a number of files into pages in the docs"
+
+    You may have configuration files you want to add to the documentation for reference.
+    You should add your workflow to process these files to `docs/hooks.py`.
+    In that file, you can find examples of how we do it for other files (e.g. the python API and the example notebooks).
+
+??? question "I want to view my documentation changes locally"
+
+    You can serve your documentation locally by calling `mkdocs serve` from the command line with [your development environment](#setting-up-a-development-environment) activated.
+    Once the documentation has been built you will see a link to navigate to in your browser, most likely <http://127.0.0.1:8000>.
+    When you make changes to your documentation, `mkdocs` will automatically rebuild everything so that you can check the effects of your changes without needing to rerun `mkdocs serve`.
+
+??? question "I want to do something else"
+
+    We recommend exploring the [MkDocs](https://www.mkdocs.org/) and the [Material](https://squidfunk.github.io/mkdocs-material/) documentation if we haven't answered your question.
+
 ## Updating the project when the template updates
 
 This project has been built with [cruft](https://cruft.github.io/cruft/) based on the [Arup Cookiecutter template](https://github.com/arup-group/cookiecutter-pypackage).
-When changes are made to the base template, they can be merged into this project by running `cruft update` from the  `osmox` mamba environment.
+When changes are made to the base template, they can be merged into this project by running `cruft update` from the  `osmox` conda environment.
 
 You may be prompted to do this when you open a Pull Request, if our automated checks identify that the template is newer than that used in the project.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,20 +1,27 @@
 
 # Installation
 
-## Setting up a user environment
+## Installing a user environment
 
-As a `osmox` user, it is easiest to install using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
+As a `osmox` user, it is easiest to install using the [conda](https://docs.conda.io/en/latest/) package manager, as follows:
 
-1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
-1. Open the command line (or the "miniforge prompt" in Windows).
-1. Create the osmox mamba environment: `mamba create -n osmox -c conda-forge -c city-modelling-lab osmox`
-1. Activate the osmox mamba environment: `mamba activate osmox`
+1. Install conda with the [miniforge](https://github.com/conda-forge/miniforge?tab=readme-ov-file#download) executable for your operating system.
+   Arup users on Windows can install `miniforge` from the Arup software shop by downloading "VS Code for Python".
+1. Open the command line (or the VSCode "integrated terminal" in Windows).
+1. Create the osmox conda environment: `conda create -n osmox -c conda-forge -c city-modelling-lab osmox`
+1. Activate the osmox conda environment: `conda activate osmox`
 
 All together:
 
 --8<-- "README.md:docs-install-user"
 
-## Setting up a development environment
+!!! tip
+    If you are an Arup user and are having difficulties with creating the `conda` environment, it may be due to *SSL certificates*.
+    You'll know that this is the case because there will be mention of "SSL" in the error trace.
+    Search `SSL Certificates` on the Arup internal Sharepoint to find instructions on adding the certificates for `conda`.
+    Windows users who have installed "VS Code for Python" from the software shop should have all the relevant certificates in place, but you will need to follow the instructions given on the SharePoint troubleshooting page if you want to run the command from in a Windows Subsystem for Linux (WSL) session.
+
+## Installing a development environment
 
 The install instructions are slightly different to create a development environment compared to a user environment:
 

--- a/docs/static/hooks.py
+++ b/docs/static/hooks.py
@@ -147,7 +147,9 @@ def _get_nav_list(nav: list[dict | str], ref: str) -> list:
     Returns:
         list: Nav sub-list linked to `ref`.
     """
-    nav_ref = [idx for idx in nav if isinstance(idx, dict) and set(idx.keys()) == {ref}][0]
+    nav_ref = [
+        idx for idx in nav if isinstance(idx, dict) and set(idx.keys()) == {ref}
+    ][0]
     return nav_ref[ref]
 
 

--- a/docs/static/hooks.py
+++ b/docs/static/hooks.py
@@ -1,3 +1,5 @@
+"""Hooks to run when building documentation."""
+
 import tempfile
 from pathlib import Path
 
@@ -13,8 +15,17 @@ API_FILES_TO_IGNORE = ["cli.py"]
 
 # Bump priority to ensure files are moved before jupyter notebook conversion takes place
 @mkdocs.plugins.event_priority(50)
-def on_files(files: list, config: dict, **kwargs):
-    """Link (1) top-level files to mkdocs files and (2) generate the python API documentation."""
+def on_files(files: list, config: dict, **kwargs) -> list:
+    """Link (1) top-level files to mkdocs files and (2) generate the python API documentation.
+
+    Args:
+        files (list): mkdocs file list.
+        config (dict): mkdocs config dictionary.
+        **kwargs: Automatic MKDocs hook inputs.
+
+    Returns:
+        list: Updated mkdocs file list.
+    """
     for file in Path("./resources").glob("**/*.*"):
         files.append(_new_file(file, config))
     files.append(_new_file(Path("./CHANGELOG.md"), config))
@@ -48,7 +59,7 @@ def _new_file(path: Path, config: dict, src_dir: str = ".") -> File:
 
 
 def _api_gen(files: list, config: dict) -> dict:
-    """Project Python API generator
+    """Project Python API generator.
 
     Args:
         files (list): mkdocs file list.
@@ -78,6 +89,7 @@ def _py_to_md(filepath: Path, api_nav: dict, config: dict) -> File:
         filepath (Path): Path to python file relative to the package source code directory.
         api_nav (dict): Nested dictionary to fill with mkdocs navigation entries.
         config (Config): mkdocs config dictionary.
+
     Returns:
         File: mkdocs object that links the temp file to the docs directory, ready to be added to the mkdocs file list.
     """
@@ -112,7 +124,6 @@ def _update_nav(api_nav: dict, config: dict) -> None:
         api_nav (dict): Python API navigation tree.
         config (dict): mkdocs config dictionary (in which `nav` can be found).
     """
-
     api_reference_nav = {
         "Python API": [*api_nav.pop("top_level"), *[{k: v} for k, v in api_nav.items()]]
     }
@@ -121,6 +132,7 @@ def _update_nav(api_nav: dict, config: dict) -> None:
 
 def _get_nav_list(nav: list[dict | str], ref: str) -> list:
     """Get navigation entry sub-page list.
+
     Navigation list entries can be dictionaries or strings.
     Sub-list entries can then also be dictionaries or strings. E.g.,
 
@@ -172,6 +184,6 @@ def on_post_build(**kwargs):
     """After mkdocs has finished building the docs, remove the temporary directory of markdown files.
 
     Args:
-        config (Config): mkdocs config dictionary (unused).
+        **kwargs: Automatic MKDocs hook inputs.
     """
     TEMPDIR.cleanup()

--- a/linkcheck.json
+++ b/linkcheck.json
@@ -1,0 +1,17 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": "^https://github.com/arup-group"
+      },
+      {
+        "pattern": "^https://arup.sharepoint.com"
+      },
+      {
+        "pattern": "^https://arup-my.sharepoint.com"
+      },
+      {
+        "pattern": "^https://aws.arup.com"
+      },
+    ]
+
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,6 @@ theme:
     - navigation.indexes
     - navigation.top
     - content.code.copy
-    - content.code.annotate
 repo_url: https://github.com/arup-group/osmox/
 site_dir: .docs
 markdown_extensions:
@@ -31,13 +30,12 @@ markdown_extensions:
       anchor_linenums: true
       line_spans: __span
       pygments_lang_class: true
-  - pymdownx.inlinehilite
+  - pymdownx.inlinehilite:
+      style_plain_text: shell
   - pymdownx.superfences
   - pymdownx.snippets
   - pymdownx.tabbed:
       alternate_style: true
-  - pymdownx.tasklist:
-      clickable_checkbox: true
   - toc:
       permalink: "#"
       toc_depth: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,40 +25,74 @@ directory = "reports/coverage"
 [tool.coverage.xml]
 output = "reports/coverage/coverage.xml"
 
-[tool.black]
-line-length = 100
-skip-magic-trailing-comma = true
-
 [tool.ruff]
 line-length = 100
+preview = true # required to activate many pycodestyle errors and warnings as of 2024-03-13
+
+[tool.ruff.format]
+exclude = [".*.egg-info", "requirements/**"]
+skip-magic-trailing-comma = true
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "Q"]
-
+select = [
+    # pycodestyle errors
+    "E",
+    # pycodestyle warnings
+    "W",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    # Docstrings
+    "D"
+]
 ignore = [
-    "E501", # line too long: Black will handle this.
-    "D1",   # Ignore missing docstrings in public functions/modules. There are just too many of them missing...
+    # here and below, rules are redundant with formatter, see
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "E501",
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300"
 ]
 
-# Exclude a variety of commonly ignored directories.
-exclude = [".*", "__pypackages__", "build", "dist", "venv", "reports/"]
-
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+[tool.ruff.lint.isort]
+split-on-trailing-comma = false
 
 [tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
-[tool.ruff.lint.per-file-ignores]
 # Ignore `E402` (import violations) and `F401` (unused imports) in all `__init__.py` files
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]
+"*.ipynb" = ["E402"]
+"tests/*" = ["D"]
 
-[tool.ruff.lint.flake8-quotes]
-docstring-quotes = "double"
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 200
+ignore-overlong-task-comments = true
+
+[tool.codespell]
+skip = "tests/*.py,AUTHORS.md"
+count = ""
+quiet-level = 3
+# Uncomment and add words that are false flags as a comma delimited string
+# ignore-words-list = ""
 
 [tool.setuptools.packages.find]
 include = ["osmox*"]

--- a/src/osmox/cli.py
+++ b/src/osmox/cli.py
@@ -20,8 +20,7 @@ logger = logging.getLogger(__name__)
 @click.version_option()
 @click.group()
 def cli():
-    """
-    OSMOX Command Line Tool.
+    """OSMOX Command Line Tool.
     """
     pass
 
@@ -29,8 +28,7 @@ def cli():
 @cli.command()
 @click.argument("config_path", nargs=1, type=PathPath(exists=True), required=True)
 def validate(config_path):
-    """
-    Validate a config.
+    """Validate a config.
     """
     cnfg = config.load(config_path)
     config.validate_activity_config(cnfg)
@@ -76,10 +74,14 @@ def run(config_path, input_path, output_name, format, crs, single_use, lazy):
     if single_use:
         logger.info("Handler is single-use, activities will get unique locations.")
     if lazy:
-        logger.info("Handler will be using lazy assignment, this may suppress some multi-use.")
+        logger.info(
+            "Handler will be using lazy assignment, this may suppress some multi-use."
+        )
 
     handler = build.ObjectHandler(config=cnfg, crs=crs, lazy=lazy)
-    logger.info(f" Filtering all objects found in {input_path}. This may take a long while.")
+    logger.info(
+        f" Filtering all objects found in {input_path}. This may take a long while."
+    )
     handler.apply_file(str(input_path), locations=True, idx="flex_mem")
     logger.info(f" Found {len(handler.objects)} buildings.")
     logger.info(f" Found {len(handler.points)} nodes with valid tags.")
@@ -130,6 +132,8 @@ def run(config_path, input_path, output_name, format, crs, single_use, lazy):
     if pyproj.CRS(crs) != pyproj.CRS("epsg:4326"):
         logger.info(" Reprojecting additional output to EPSG:4326 (lat lon)")
         gdf_4326 = gdf.to_crs("epsg:4326")
-        getattr(gdf_4326, writer_method)(f"{output_name}_epsg_4326.{extension}", **kwargs)
+        getattr(gdf_4326, writer_method)(
+            f"{output_name}_epsg_4326.{extension}", **kwargs
+        )
 
     logger.info("Done.")

--- a/src/osmox/config.py
+++ b/src/osmox/config.py
@@ -12,7 +12,7 @@ with importlib.resources.as_file(SCHEMA_FILE) as f:
 
 def load(config_path):
     logger.warning(f"Loading config from '{config_path}'.")
-    with open(config_path, "r") as read_file:
+    with open(config_path) as read_file:
         return json.load(read_file)
 
 
@@ -61,7 +61,9 @@ def validate_activity_config(config):
     if "distance_to_nearest" in config:
         act_diff = set(config["distance_to_nearest"]).difference(acts)
         if act_diff:
-            raise ValueError(f"'Distance to nearest' has non-configured activities: {act_diff}")
+            raise ValueError(
+                f"'Distance to nearest' has non-configured activities: {act_diff}"
+            )
 
     if "fill_missing_activities" in config:
         for group in config["fill_missing_activities"]:

--- a/src/osmox/helpers.py
+++ b/src/osmox/helpers.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import Union
 
 import click
 import geopandas as gp
@@ -20,8 +19,7 @@ class PathPath(click.Path):
 
 
 class AutoTree(index.Index):
-    """
-    Spatial bounding box transforming (using pyproj) and indexing (using Rtree).
+    """Spatial bounding box transforming (using pyproj) and indexing (using Rtree).
     """
 
     def __init__(self):
@@ -50,8 +48,7 @@ class AutoTree(index.Index):
 
 
 def dict_list_match(d, dict_list):
-    """
-    Check if simple key value pairs from dict d are in dictionary of lists.
+    """Check if simple key value pairs from dict d are in dictionary of lists.
     eg:
     dict_list_match({1:2}, {1:[1,2,3]}) == True
     dict_list_match({1:4}, {1:[1,2,3]}) == False
@@ -65,8 +62,7 @@ def dict_list_match(d, dict_list):
 
 
 def height_to_m(height):
-    """
-    Parse height to float in metres.
+    """Parse height to float in metres.
     """
     height.strip()
 
@@ -99,8 +95,7 @@ def is_string_float(number):
 
 
 def imperial_to_metric(height):
-    """
-    Convert imperial (feet and inches) to metric (metres).
+    """Convert imperial (feet and inches) to metric (metres).
     Expect formatted as 3'4" (3 feet and 4 inches) or 3' (3 feet).
     Return float
     """
@@ -110,9 +105,10 @@ def imperial_to_metric(height):
     return round(inches / 39.3701, 3)
 
 
-def progressBar(iterable, prefix="", suffix="", decimals=1, length=100, fill="|", printEnd="\r"):
-    """
-    from here: https://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console
+def progressBar(
+    iterable, prefix="", suffix="", decimals=1, length=100, fill="|", printEnd="\r"
+):
+    """From here: https://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console
     Call in a loop to create terminal progress bar
     @params:
         iteration   - Required  : current iteration (Int)
@@ -128,7 +124,9 @@ def progressBar(iterable, prefix="", suffix="", decimals=1, length=100, fill="|"
 
     # Progress Bar Printing Function
     def printProgressBar(iteration):
-        percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+        percent = ("{0:." + str(decimals) + "f}").format(
+            100 * (iteration / float(total))
+        )
         filledLength = int(length * iteration // total)
         bar = fill * filledLength + "-" * (length - filledLength)
         print(f"\r{prefix} |{bar}| {percent}% {suffix}", end=printEnd)
@@ -144,8 +142,7 @@ def progressBar(iterable, prefix="", suffix="", decimals=1, length=100, fill="|"
 
 
 def get_distance(p):
-    """
-    Return the distance between two shapely points
+    """Return the distance between two shapely points
     Assumes orthogonal projection in meters
     :params tuple p: A tuple conctaining two Shapely points
 
@@ -188,7 +185,9 @@ def area_grid(area, spacing):
 def fill_object(i, point, size, new_osm_tags, new_tags, required_acts):
     geom = point_to_poly(point, size)
     idx = f"fill_{i}"
-    object = build.Object(idx=idx, osm_tags=new_osm_tags, activity_tags=new_tags, geom=geom)
+    object = build.Object(
+        idx=idx, osm_tags=new_osm_tags, activity_tags=new_tags, geom=geom
+    )
     object.activities = list(required_acts)
     return object
 
@@ -205,7 +204,7 @@ def path_leaf(filepath):
     return folder_path
 
 
-def read_geofile(filepath: Union[str, Path]) -> gp.GeoDataFrame:
+def read_geofile(filepath: str | Path) -> gp.GeoDataFrame:
     filepath_extension = Path(filepath).suffixes
     if ".parquet" in filepath_extension:
         return gp.read_parquet(filepath)

--- a/tests/test_autotree.py
+++ b/tests/test_autotree.py
@@ -25,7 +25,9 @@ def test_autotree_point_point_intersection():
     tree.auto_insert(target)
     tree.auto_insert(
         build.OSMObject(
-            idx=0, activity_tags=[build.OSMTag(key="b", value="b")], geom=Point((10, 10))
+            idx=0,
+            activity_tags=[build.OSMTag(key="b", value="b")],
+            geom=Point((10, 10)),
         )
     )
     geom = Point((0, 0))
@@ -40,7 +42,9 @@ def test_autotree_point_poly_intersection():
     tree.auto_insert(target)
     tree.auto_insert(
         build.OSMObject(
-            idx=0, activity_tags=[build.OSMTag(key="b", value="b")], geom=Point((10, 10))
+            idx=0,
+            activity_tags=[build.OSMTag(key="b", value="b")],
+            geom=Point((10, 10)),
         )
     )
     geom = Polygon([(-1, -1), (-1, 1), (1, 1), (1, -1), (-1, -1)])
@@ -57,7 +61,9 @@ def test_autotree_poly_poly_intersection():
     tree.auto_insert(target)
     tree.auto_insert(
         build.OSMObject(
-            idx=0, activity_tags=[build.OSMTag(key="b", value="b")], geom=Point((10, 10))
+            idx=0,
+            activity_tags=[build.OSMTag(key="b", value="b")],
+            geom=Point((10, 10)),
         )
     )
     geom = Polygon([(-1, -1), (-1, 1), (1, 1), (1, -1), (-1, -1)])
@@ -69,7 +75,9 @@ def test_autotree_iter():
     for i in range(3):
         tree.auto_insert(
             build.OSMObject(
-                idx=0, activity_tags=[build.OSMTag(key="b", value="b")], geom=Point((10, 10))
+                idx=0,
+                activity_tags=[build.OSMTag(key="b", value="b")],
+                geom=Point((10, 10)),
             )
         )
     out = [o for o in tree]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,11 @@ from osmox import cli, helpers
 
 logging.basicConfig(level=logging.INFO)
 
-MAP_EXTENSIONS = {"geopackage": ".gpkg", "geojson": ".geojson", "geoparquet": ".parquet"}
+MAP_EXTENSIONS = {
+    "geopackage": ".gpkg",
+    "geojson": ".geojson",
+    "geoparquet": ".parquet",
+}
 
 
 @pytest.fixture
@@ -66,11 +70,24 @@ def test_cli_with_default_args(
 
 @pytest.mark.parametrize("output_format", ["geojson", "geopackage", "geoparquet"])
 def test_cli_output_formats(
-    runner, config_path, toy_osm_path, path_output_dir, default_output_file_path, output_format
+    runner,
+    config_path,
+    toy_osm_path,
+    path_output_dir,
+    default_output_file_path,
+    output_format,
 ):
     result = runner.invoke(
         cli.run,
-        [config_path, toy_osm_path, path_output_dir, "-f", output_format, "-crs", "epsg:4326"],
+        [
+            config_path,
+            toy_osm_path,
+            path_output_dir,
+            "-f",
+            output_format,
+            "-crs",
+            "epsg:4326",
+        ],
     )
     check_exit_code(result)
     new_file = default_output_file_path.with_suffix(MAP_EXTENSIONS[output_format])
@@ -86,7 +103,9 @@ def test_cli_output_formats(
 def test_cli_output_crs(
     runner, config_path, toy_osm_path, path_output_dir, crs, default_output_file_path
 ):
-    result = runner.invoke(cli.run, [config_path, toy_osm_path, path_output_dir, "-crs", crs])
+    result = runner.invoke(
+        cli.run, [config_path, toy_osm_path, path_output_dir, "-crs", crs]
+    )
     check_exit_code(result)
 
     # test that file with default crs is still produced

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,10 @@ def valid_config():
                 "pub": ["social", "work", "delivery"],
                 "fast_food": ["work", "delivery", "food_shop"],
             },
-            "landuse": {"commercial": ["shop", "work", "delivery"], "residential": ["home"]},
+            "landuse": {
+                "commercial": ["shop", "work", "delivery"],
+                "residential": ["home"],
+            },
             "shop": {"*": ["shop", "work"]},
             "public_transport": {"*": ["transit"]},
             "highway": {"bus_stop": ["transit"]},
@@ -91,7 +94,10 @@ def test_get_tags(valid_config):
 def test_valid_config_logging(caplog, valid_config):
     caplog.set_level(logging.INFO)
     config.validate_activity_config(valid_config)
-    assert "['delivery', 'food_shop', 'home', 'shop', 'social', 'transit', 'work']" in caplog.text
+    assert (
+        "['delivery', 'food_shop', 'home', 'shop', 'social', 'transit', 'work']"
+        in caplog.text
+    )
 
 
 def test_config_with_missing_filter_logging(valid_config):
@@ -106,7 +112,8 @@ def test_config_with_missing_activity_mapping_logging(valid_config):
     valid_config.pop("activity_mapping")
 
     with pytest.raises(
-        jsonschema.exceptions.ValidationError, match="'activity_mapping' is a required property"
+        jsonschema.exceptions.ValidationError,
+        match="'activity_mapping' is a required property",
     ):
         config.validate_activity_config(valid_config)
 
@@ -131,13 +138,16 @@ def test_config_with_unsupported_distance_to_nearest_activity_logging(valid_conf
 def test_config_with_missing_fill_missing_activities_key_logging(valid_config):
     valid_config["fill_missing_activities"][0].pop("required_acts")
     with pytest.raises(
-        jsonschema.exceptions.ValidationError, match="'required_acts' is a required property"
+        jsonschema.exceptions.ValidationError,
+        match="'required_acts' is a required property",
     ):
         config.validate_activity_config(valid_config)
 
 
 def test_config_with_invalid_activity_for_fill_missing_activities_logging(valid_config):
-    valid_config["fill_missing_activities"][0]["required_acts"].append("invalid_activity")
+    valid_config["fill_missing_activities"][0]["required_acts"].append(
+        "invalid_activity"
+    )
     with pytest.raises(
         ValueError,
         match="'Fill missing activities' group has non-configured activities: {'invalid_activity'}",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -48,8 +48,16 @@ def test_build_bounding_box_grid_from_areas(area, spacing, expected):
     [
         (Polygon([(0, 0), (0, 50), (50, 50), (0, 0)]), [100, 100], [(0, 0)]),
         (Polygon([(0, 0), (0, 50), (50, 50), (0, 0)]), [51, 51], [(0, 0)]),
-        (Polygon([(0, 0), (0, 50), (50, 50), (0, 0)]), [50, 50], [(0, 0), (0, 50), (50, 50)]),
-        (Polygon([(0, 0), (0, 50), (10, 50), (0, 0)]), [25, 25], [(0, 0), (0, 25), (0, 50)]),
+        (
+            Polygon([(0, 0), (0, 50), (50, 50), (0, 0)]),
+            [50, 50],
+            [(0, 0), (0, 50), (50, 50)],
+        ),
+        (
+            Polygon([(0, 0), (0, 50), (10, 50), (0, 0)]),
+            [25, 25],
+            [(0, 0), (0, 25), (0, 50)],
+        ),
     ],
 )
 def test_build_area_grid_from_areas(area, spacing, expected):
@@ -58,7 +66,9 @@ def test_build_area_grid_from_areas(area, spacing, expected):
 
 def test_fill_objects():
     p = (0, 0)
-    obj = helpers.fill_object(0, p, [10, 10], [["osm_tag", 1]], [["new_tags", 2]], ["act"])
+    obj = helpers.fill_object(
+        0, p, [10, 10], [["osm_tag", 1]], [["new_tags", 2]], ["act"]
+    )
     assert obj.geom.equals(Polygon([(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)]))
     assert obj.idx == "fill_0"
     assert obj.activities == ["act"]


### PR DESCRIPTION
- Fixes #60

Changelog not updated; this is not a user-facing change.

I used `cruft update` to pull in the latest versions of the cookie-cutter managed workflows.

Some of the changes are not related to the cookie-cutter template. When we updated this repo to the latest version of the template (that's essentially what this PR is about), an additional `pre-commit.ci` check was introduced that does a bunch of linting on the code. It blew up with a bunch of complaints about missing dosctrings, unused imports, etc. You can instruct the tool to autofix all of the lining errors, which I did with [this comment](https://github.com/arup-group/osmox/pull/61#issuecomment-2757411542). The tool then made [this commit](https://github.com/arup-group/osmox/pull/61/commits/73819aa683838a8865ee1b31df39f0dc5e89127e) to fix all of the lining errors it identified.

## Before

[Broken (daily) CI build ](https://github.com/arup-group/osmox/actions/runs/14085878580) caused by an invalid workflow file.

<img width="1671" alt="Screenshot 2025-03-26 at 20 42 25" src="https://github.com/user-attachments/assets/cf2e30e5-8de6-4ba1-a67c-60039dee3d4f" />


## After

[Passing CI build](https://github.com/arup-group/osmox/actions/runs/14093055017), albeit using a different workflow file:

<img width="1675" alt="Screenshot 2025-03-26 at 20 44 38" src="https://github.com/user-attachments/assets/df7f0164-fd1f-478c-9ec4-014ffac6f466" />


## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Tests added to cover contribution
- [x] Documentation updated
